### PR TITLE
Fix Azure tz2 encoding issue

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,14 +29,6 @@
   branch = "master"
   name = "github.com/btcsuite/btcutil"
 
-[[constraint]]
-  branch = "master"
-  name = "github.com/golang/crypto"
-
 [prune]
   go-tests = true
   unused-packages = true
-
-[[constraint]]
-  name = "github.com/Azure/azure-sdk-for-go"
-  version = "28.1.0"

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -43,6 +43,9 @@ func ECCoordinateFromPrivateKey(d []byte, curveName string) (xBytes, yBytes []by
 	return
 }
 
+// CanonizeEncodeP256K returns the canonical versions of the signature
+// the canonical version enforce low S values
+// if S is above order / 2 it negating the S (modulo the order (N))
 func CanonizeEncodeP256K(sig []byte) []byte {
 	r := sig[:32]
 	s := sig[32:]
@@ -60,5 +63,4 @@ func CanonizeEncodeP256K(sig []byte) []byte {
 	r = rInt.Bytes()
 	signature := append(r, s...)
 	return signature
-
 }

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -2,6 +2,7 @@ package crypto
 
 import (
 	"crypto/elliptic"
+	"math/big"
 
 	"github.com/decred/dcrd/dcrec/secp256k1"
 )
@@ -40,4 +41,24 @@ func ECCoordinateFromPrivateKey(d []byte, curveName string) (xBytes, yBytes []by
 	xBytes = x.Bytes()
 	yBytes = y.Bytes()
 	return
+}
+
+func CanonizeEncodeP256K(sig []byte) []byte {
+	r := sig[:32]
+	s := sig[32:]
+	rInt := new(big.Int).SetBytes(r)
+	sInt := new(big.Int).SetBytes(s)
+
+	order := secp256k1.S256().N
+	two := new(big.Int).SetBytes([]byte{0x02})
+	quo := new(big.Int).Quo(order, two)
+	if sInt.Cmp(quo) > 0 {
+		sInt = sInt.Sub(order, sInt)
+	}
+
+	s = sInt.Bytes()
+	r = rInt.Bytes()
+	signature := append(r, s...)
+	return signature
+
 }

--- a/tezos/encoding.go
+++ b/tezos/encoding.go
@@ -95,6 +95,10 @@ func EncodeSig(pubKeyHash string, sig []byte) string {
 		return ""
 	}
 
+	if curveName == crypto.CurveP256K {
+		sig = crypto.CanonizeEncodeP256K(sig)
+	}
+
 	return base58CheckEncodePrefix(prefixMap[sigPrefix], sig)
 }
 
@@ -109,6 +113,14 @@ func EncodePubKey(pubKeyHash string, pubKey []byte) string {
 	}
 
 	return base58CheckEncodePrefix(prefixMap[pubKeyPrefix], pubKey)
+}
+
+func DecodeKey(prefix []byte, key string) ([]byte, error) {
+	decoded, _, err := base58.CheckDecode(key)
+	if err != nil {
+		return nil, err
+	}
+	return decoded[len(prefix)-1:], nil
 }
 
 func decodeKey(prefix []byte, key string) ([]byte, error) {

--- a/tezos/encoding.go
+++ b/tezos/encoding.go
@@ -115,14 +115,6 @@ func EncodePubKey(pubKeyHash string, pubKey []byte) string {
 	return base58CheckEncodePrefix(prefixMap[pubKeyPrefix], pubKey)
 }
 
-func DecodeKey(prefix []byte, key string) ([]byte, error) {
-	decoded, _, err := base58.CheckDecode(key)
-	if err != nil {
-		return nil, err
-	}
-	return decoded[len(prefix)-1:], nil
-}
-
 func decodeKey(prefix []byte, key string) ([]byte, error) {
 	decoded, _, err := base58.CheckDecode(key)
 	if err != nil {


### PR DESCRIPTION
Tezos require secp256k1 signature to be encoded using the canonical version of the signature.

This is not the encoding that Azure give by default.

This MR add an extra step in case of tz2 signature encoding to support this format