### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ three algorithms supported by Tezos.
 |                  | tz1 | tz2 | tz3 |
 | ---------------- | --- | --- | --- |
 | Google Cloud KMS | ☒   | ☒   | ☑   |
-| AWS KMS          | ☒   | ☒   | ☑   |
+| AWS KMS          | ☒   | ☑   | ☑   |
 | Azure KMS        | ☒   | ☑   | ☑   |
 | YubiHSM2         | ☑   | ☑   | ☑   |
 


### PR DESCRIPTION
AWS' Cloud HSM supports the Secp256k1 curve since February 2019: https://twitter.com/rwitoff/status/1093639831672868865