### PR TITLE
Issue 83: adding chain id to logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,5 @@ COLLECTOR_PKG = github.com/ecadlabs/signatory/pkg/metrics
 
 signatory:
 	go build -ldflags "-X $(COLLECTOR_PKG).GitRevision=$(GIT_REVISION) -X $(COLLECTOR_PKG).GitBranch=$(GIT_BRANCH)" ./cmd/signatory
+signatory-cli:
+	go build -ldflags "-X $(COLLECTOR_PKG).GitRevision=$(GIT_REVISION) -X $(COLLECTOR_PKG).GitBranch=$(GIT_BRANCH)" ./cmd/signatory-cli

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   signatory:
-      build: .
+      image: ecadlabs/signatory
       ports:
         - "80:80"
       volumes: 

--- a/pkg/signatory/signatory.go
+++ b/pkg/signatory/signatory.go
@@ -197,7 +197,7 @@ func (s *Signatory) Sign(ctx context.Context, keyHash string, message []byte) (s
 
 	switch msgKind {
 	case opEndorsement:
-		l = l.WithField(logChainID, msg.getChainID())
+		l = l.WithField(logChainID, msg.GetChainID())
 	// case opBlock:
 	}
 	

--- a/pkg/signatory/signatory.go
+++ b/pkg/signatory/signatory.go
@@ -31,7 +31,7 @@ const (
 	logOp        = "op"
 	logKind      = "kind"
 	logKeyID     = "key_id"
-	logChainID	 = "chain_id"
+	logChainID   = "chain_id"
 )
 
 // SignInterceptor is an observer function for signing request
@@ -184,20 +184,19 @@ func (s *Signatory) Sign(ctx context.Context, keyHash string, message []byte) (s
 		l.WithField("raw", hex.EncodeToString(message)).Error(err)
 		return "", errors.Wrap(err, http.StatusBadRequest)
 	}
-	
-	l = l.WithField(logOp, msg.MessageKind())	
-		
+
+	l = l.WithField(logOp, msg.MessageKind())
+
 	var opKind []string
 	if ops, ok := msg.(*tezos.UnsignedOperation); ok {
 		opKind = ops.OperationKinds()
 		l = l.WithField(logKind, opKind)
 	}
-	
+
 	if msgWithChainID, ok := msg.(tezos.MessageWithLevelAndChainID); ok {
 		chainID := msgWithChainID.GetChainID()
 		l = l.WithField(logChainID, chainID)
 	}
-
 
 	p, err := s.getPublicKey(ctx, keyHash)
 	if err != nil {

--- a/pkg/signatory/signatory.go
+++ b/pkg/signatory/signatory.go
@@ -94,7 +94,7 @@ func (k *keyCache) get(pkh string) *keyVaultPair {
 	defer k.mtx.Unlock()
 
 	if pair, ok := k.cache[pkh]; ok {
-		return pairS
+		return pair
 	}
 
 	return nil

--- a/pkg/signatory/signatory.go
+++ b/pkg/signatory/signatory.go
@@ -195,7 +195,7 @@ func (s *Signatory) Sign(ctx context.Context, keyHash string, message []byte) (s
 
 	if msgWithChainID, ok := msg.(tezos.MessageWithLevelAndChainID); ok {
 		chainID := msgWithChainID.GetChainID()
-		l = l.WithField(logChainID, chainID)
+		l = l.WithField(logChainID, "chain_id_should_be_here")
 	}
 
 	p, err := s.getPublicKey(ctx, keyHash)

--- a/pkg/signatory/signatory.go
+++ b/pkg/signatory/signatory.go
@@ -195,7 +195,7 @@ func (s *Signatory) Sign(ctx context.Context, keyHash string, message []byte) (s
 
 	if msgWithChainID, ok := msg.(tezos.MessageWithLevelAndChainID); ok {
 		chainID := msgWithChainID.GetChainID()
-		l = l.WithField(logChainID, "chain_id_should_be_here")
+		l = l.WithField(logChainID, chainID)
 	}
 
 	p, err := s.getPublicKey(ctx, keyHash)

--- a/pkg/tezos/message.go
+++ b/pkg/tezos/message.go
@@ -32,14 +32,13 @@ const (
 
 // UnsignedMessage is implemented by all kinds of sign request payloads
 type UnsignedMessage interface {
-	MessageKind() string
-	GetChainID() string
+	MessageKind() string	
 }
 
 // UnsignedOperation represents operation without a signature
 type UnsignedOperation struct {
 	Branch   string
-	Contents []OperationContents
+	Contents []OperationContents	
 }
 
 // MessageKind returns unsigned message kind name i.e. "generic"

--- a/pkg/tezos/message.go
+++ b/pkg/tezos/message.go
@@ -32,13 +32,13 @@ const (
 
 // UnsignedMessage is implemented by all kinds of sign request payloads
 type UnsignedMessage interface {
-	MessageKind() string	
+	MessageKind() string
 }
 
 // UnsignedOperation represents operation without a signature
 type UnsignedOperation struct {
 	Branch   string
-	Contents []OperationContents	
+	Contents []OperationContents
 }
 
 // MessageKind returns unsigned message kind name i.e. "generic"

--- a/pkg/tezos/message.go
+++ b/pkg/tezos/message.go
@@ -33,6 +33,7 @@ const (
 // UnsignedMessage is implemented by all kinds of sign request payloads
 type UnsignedMessage interface {
 	MessageKind() string
+	getChainID() string
 }
 
 // UnsignedOperation represents operation without a signature

--- a/pkg/tezos/message.go
+++ b/pkg/tezos/message.go
@@ -33,7 +33,7 @@ const (
 // UnsignedMessage is implemented by all kinds of sign request payloads
 type UnsignedMessage interface {
 	MessageKind() string
-	getChainID() string
+	GetChainID() string
 }
 
 // UnsignedOperation represents operation without a signature


### PR DESCRIPTION
updated pkg/signatory/signatory.go file to retrieve a chain id from a message and adding it to logs

# Test

- Endorsement
```
curl -XPOST \
      -d '"029caecab9db439a2dd462570a929bef822cb94441b80f9f728faeb1b3    d9235250770f1e8f0000061ddc"' \
      localhost:6732/keys/tz1SVwdLNf3ANMQE1AXrxS1pBG8tcn2joVZg
```
 

- Block
```
curl -XPOST \
      -d '"019caecab900061de402e27da655a04eaa5dad0647e6ff56d11a5da8ef    b48c2e90570e27853839e76b68000000005eb576f5047ab08836902391c075dc9264    0f9d7496faa8cff5b2b24450786d86349b9a528d0000001100000001010000000800    00000000061de3ad348c90c42bc5b90e89837fdbeb6c1360be7181c9116ef2eb8cb6    3ebbb1380e00000675d7e0ffa2030000"' \
      localhost:6732/keys/tz1SVwdLNf3ANMQE1AXrxS1pBG8tcn2joVZg
```

- Transaction 
```
curl -XPOST \
      -d '"038cc206312a229a6560bb9f9af59ea5b64d7795c8f6743149f62ff0bd    390783fc6c004b415314d2b56b0481a3ae8c992ce8bb8dba0369840a98cb2dc35000    80ade2040000d726cdeb8f0344c89ff4c9a2e24bbe8dfe3762be00"' \
     localhost:6732/keys/tz1SVwdLNf3ANMQE1AXrxS1pBG8tcn2joVZg  
```

# Result:  log messages with the chain id
```
INFO[0036] Requesting signing operation                  ***chain_id=NetXjD3HPJJjmcd op=endorsement** pkh=tz1SVwdLNf3ANMQE1AXrxS1pBG8tcn2joVZg vault=File vault_name=local_file_keys
INFO[0036] About to sign raw bytes                       chain_id=NetXjD3HPJJjmcd op=endorsement pkh=tz1SVwdLNf3ANMQE1AXrxS1pBG8tcn2joVZg raw=029caecab9db439a2dd462570a929bef822cb94441b80f9f728faeb1b3d9235250770f1e8f0000061ddc vault=File vault_name=local_file_keys
INFO[0036] Signed endorsement successfully               chain_id=NetXjD3HPJJjmcd op=endorsement pkh=tz1SVwdLNf3ANMQE1AXrxS1pBG8tcn2joVZg vault=File vault_name=local_file_keys
INFO[0036] POST /keys/tz1SVwdLNf3ANMQE1AXrxS1pBG8tcn2joVZg  duration="650.225µs" hostname="localhost:6732" method=POST path=/keys/tz1SVwdLNf3ANMQE1AXrxS1pBG8tcn2joVZg start_time="2020-05-08T16:18:28Z" status=200
INFO[0036] Requesting signing operation                  **chain_id=NetXjD3HPJJjmcd op=block** pkh=tz1SVwdLNf3ANMQE1AXrxS1pBG8tcn2joVZg vault=File vault_name=local_file_keys
INFO[0036] About to sign raw bytes                       chain_id=NetXjD3HPJJjmcd op=block pkh=tz1SVwdLNf3ANMQE1AXrxS1pBG8tcn2joVZg raw=019caecab900061de402e27da655a04eaa5dad0647e6ff56d11a5da8efb48c2e90570e27853839e76b68000000005eb576f5047ab08836902391c075dc92640f9d7496faa8cff5b2b24450786d86349b9a528d000000110000000101000000080000000000061de3ad348c90c42bc5b90e89837fdbeb6c1360be7181c9116ef2eb8cb63ebbb1380e00000675d7e0ffa2030000 vault=File vault_name=local_file_keys
INFO[0036] Signed block successfully                     chain_id=NetXjD3HPJJjmcd op=block pkh=tz1SVwdLNf3ANMQE1AXrxS1pBG8tcn2joVZg vault=File vault_name=local_file_keys
INFO[0036] POST /keys/tz1SVwdLNf3ANMQE1AXrxS1pBG8tcn2joVZg  duration="468.553µs" hostname="localhost:6732" method=POST path=/keys/tz1SVwdLNf3ANMQE1AXrxS1pBG8tcn2joVZg start_time="2020-05-08T16:18:28Z" status=200
INFO[0036] Requesting signing operation                  kind="[transaction]" op=generic pkh=tz1SVwdLNf3ANMQE1AXrxS1pBG8tcn2joVZg vault=File vault_name=local_file_keys
```
