### PR TITLE
build and push the image to Dockerhub with GoReleaser and Github Actions

### DIFF
--- a/.github/workflows/push_dockerhub.yaml
+++ b/.github/workflows/push_dockerhub.yaml
@@ -1,0 +1,30 @@
+name: push-dockerhub
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ sig
 vendor/
 .vscode
 .devcontainer
+
+dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,6 +50,9 @@ dockers:
     binaries:
     - signatory
     - signatory-cli
+    builds:
+    - signatory
+    - signatory-cli
     image_templates:
     - "technomad21c/signatory:latest"
     - "technomad21c/signatory:{{ .Tag }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,8 @@ before:
     # you may remove this if you don't use vgo
     - go mod download
 builds:
-- env:
+- id: signatory
+  env:
   - CGO_ENABLED=0
   main: ./cmd/signatory/main.go
   ldflags:
@@ -23,6 +24,35 @@ builds:
           goarch: 386
         - goos: windows
           goarch: 386
+- id: signatory-cli
+  binary: signatory-cli
+  env:
+    - CGO_ENABLED=0
+  main: ./cmd/signatory-cli/main.go
+  ldflags:
+    - -X github.com/ecadlabs/signatory/pkg/metrics.GitRevision={{.Version}}
+    - -X github.com/ecadlabs/signatory/pkg/metrics.GitBranch={{.Version}}
+  goos:
+    - freebsd
+    - linux
+    - windows
+    - darwin
+  goarch:
+    - amd64
+    - arm
+  ignore:
+    - goos: darwin
+      goarch: 386
+    - goos: windows
+      goarch: 386
+dockers:
+  - 
+    binaries:
+    - signatory
+    - signatory-cli
+    image_templates:
+    - "technomad21c/signatory:latest"
+    - "technomad21c/signatory:{{ .Tag }}"
 archives:
 - replacements:
     darwin: Darwin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3
+RUN apk --no-cache add ca-certificates
+COPY ./signatory /bin
+COPY ./signatory-cli /bin
+
+ENTRYPOINT ["/bin/signatory"]
+


### PR DESCRIPTION
This modifies .goreleaser.yaml file to build and push the images of signatory and signatory-cli to the Docker hub and adds one workflow to do the same using Github Actions on a new tag.