### PR TITLE
Update the testing curl command with a valid endorsement

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -128,7 +128,7 @@ To test the signing operation, you can send a post to Signatory. In this example
 
 ```sh
 curl -XPOST \
-    -d '"02111111111111111111"' \
+    -d '"027a06a770e6cebe5b3e39483a13ac35f998d650e8b864696e31520922c7242b88c8d2ac55000003eb6d"' \
     localhost:8003/keys/tz3Tm6UTWmPAZJaNSPAQNiMiyFSHnRXrkcHj
 ```
 


### PR DESCRIPTION
Hello 👋 

I am currently testing Signatory with a GCP Cloud KMS key and the test command in [docs/README.md](https://github.com/ecadlabs/signatory/tree/main/docs#testing) doesn't work as expected:
```
curl -XPOST -d '"02111111111111111111"' localhost:6732/keys/<my pub key in GCP>
[{"id":"failure","kind":"temporary","msg":"unexpected end of message"}]
```

I searched for tests values in other remote signer implementation and found that one which works:
```
curl -XPOST -d '"027a06a770e6cebe5b3e39483a13ac35f998d650e8b864696e31520922c7242b88c8d2ac55000003eb6d"' localhost:6732/keys/<my pub key in GCP>
{"signature":"sigWqoQAY7wMKDgn28LTkAKRGChG1ABWBLQHiNovqB6hDZ4VthgbLtdQxmwL8k8SXyycdffeLZ2KtfzpCL1sLY5VqPJwehXL"}
```