### PR TITLE
feat(aws_kms): EC2/EKS role support

### DIFF
--- a/pkg/vault/aws/awskms.go
+++ b/pkg/vault/aws/awskms.go
@@ -24,8 +24,8 @@ import (
 // Config contains AWS KMS backend configuration
 type Config struct {
 	UserName    string `yaml:"user_name" validate:"required"`
-	AccessKeyID string `yaml:"access_key_id" validate:"required"`
-	AccessKey   string `yaml:"secret_access_key" validate:"required"`
+	AccessKeyID string `yaml:"access_key_id"`
+	AccessKey   string `yaml:"secret_access_key"`
 	Region      string `yaml:"region" validate:"required"`
 }
 
@@ -163,8 +163,10 @@ func (v *Vault) Sign(ctx context.Context, digest []byte, key vault.StoredKey) (c
 
 // New creates new AWS KMS backend
 func New(ctx context.Context, config *Config) (*Vault, error) {
-	os.Setenv("AWS_ACCESS_KEY_ID", config.AccessKeyID)
-	os.Setenv("AWS_SECRET_ACCESS_KEY", config.AccessKey)
+	if config.AccessKeyID != "" {
+		os.Setenv("AWS_ACCESS_KEY_ID", config.AccessKeyID)
+		os.Setenv("AWS_SECRET_ACCESS_KEY", config.AccessKey)
+	}
 	os.Setenv("AWS_REGION", config.Region)
 	sess := session.Must(session.NewSession())
 


### PR DESCRIPTION
Make credentials optional in order to let AWS SDK fallback to other auth providers including AssumeRole pattern with EKS or previously defined env vars.