### PR TITLE
print configured keys at 'serve' startup

### DIFF
--- a/cmd/commands/list.go
+++ b/cmd/commands/list.go
@@ -2,25 +2,8 @@ package commands
 
 import (
 	"os"
-	"text/template"
 
 	"github.com/spf13/cobra"
-)
-
-const listTemplateSrc = `{{range . -}}
-Public Key Hash:    {{.PublicKeyHash}}
-Vault:              {{.VaultName}}
-ID:                 {{.ID}}
-Active:             {{.Active}}
-{{with .Policy -}}
-Allowed Operations: {{.AllowedOperations}}
-Allowed Kinds:      {{.AllowedKinds}}
-{{end}}
-{{end -}}
-`
-
-var (
-	listTpl = template.Must(template.New("list").Parse(listTemplateSrc))
 )
 
 func NewListCommand(c *Context) *cobra.Command {
@@ -28,12 +11,7 @@ func NewListCommand(c *Context) *cobra.Command {
 		Use:   "list",
 		Short: "List public keys",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			keys, err := c.signatory.ListPublicKeys(c.Context)
-			if err != nil {
-				return err
-			}
-
-			return listTpl.Execute(os.Stdout, keys)
+			return listKeys(c.signatory, os.Stdout, c.Context)
 		},
 	}
 

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -32,20 +32,22 @@ func NewRootCommand(c *Context, name string) *cobra.Command {
 		Use:   name,
 		Short: "A Tezos Remote Signer for signing block-chain operations with private keys",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) (err error) {
+			if cmd.Use == "version" {
+				return nil
+			}
+
 			// cmd always points to the top level command!!!
 			conf := config.Default()
 			if configFile != "" {
 				conf.Read(configFile)
 			}
 
-			if cmd.Use != "version" {
-				if baseDir == "" {
-					baseDir = conf.BaseDir
-				}
-				baseDir = os.ExpandEnv(baseDir)
-				if err := os.MkdirAll(baseDir, 0770); err != nil {
-					return err
-				}
+			if baseDir == "" {
+				baseDir = conf.BaseDir
+			}
+			baseDir = os.ExpandEnv(baseDir)
+			if err := os.MkdirAll(baseDir, 0770); err != nil {
+				return err
 			}
 
 			validate := config.Validator()
@@ -53,7 +55,7 @@ func NewRootCommand(c *Context, name string) *cobra.Command {
 				return err
 			}
 
-			if jsonLog == true {
+			if jsonLog {
 				log.SetFormatter(&log.JSONFormatter{})
 			}
 

--- a/cmd/commands/utils.go
+++ b/cmd/commands/utils.go
@@ -1,0 +1,33 @@
+package commands
+
+import (
+	"context"
+	"io"
+	"text/template"
+
+	"github.com/ecadlabs/signatory/pkg/signatory"
+)
+
+const listTemplateSrc = `{{range . -}}
+Public Key Hash:    {{.PublicKeyHash}}
+Vault:              {{.VaultName}}
+ID:                 {{.ID}}
+Active:             {{.Active}}
+{{with .Policy -}}
+Allowed Operations: {{.AllowedOperations}}
+Allowed Kinds:      {{.AllowedKinds}}
+{{end}}
+{{end -}}
+`
+
+var (
+	listTpl = template.Must(template.New("list").Parse(listTemplateSrc))
+)
+
+func listKeys(s *signatory.Signatory, w io.Writer, ctx context.Context) error {
+	keys, err := s.ListPublicKeys(ctx)
+	if err != nil {
+		return err
+	}
+	return listTpl.Execute(w, keys)
+}


### PR DESCRIPTION
Can be disabled with `--no-list` flag. Keys are printed via logger.