### PR TITLE
[ci] Run integration tests against all testnets

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,4 +1,4 @@
-name: Run integration tests
+name: Integration Tests
 
 on:
   push:
@@ -6,8 +6,7 @@ on:
     types: [opened]
 
 jobs:
-  test:
-    name: Test
+  integration-tests:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -9,11 +9,16 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    env:
-      NODE_ADDR: https://rpc.jakartanet.teztnets.xyz
+    strategy:
+      fail-fast: false
+      matrix:
+        testnet_endpoints:
+          - https://ghostnet.ecadinfra.com
+          - https://jakartanet.ecadinfra.com
+          - https://kathmandunet.ecadinfra.com
     steps:
       - uses: actions/checkout@v2
       - name: Build image
         run: docker build -t signatory-test -f ./integration_test/Dockerfile .
       - name: Run tests
-        run: docker run -e 'ENV_ACTIVATION_KEY=${{ secrets.FAUCET_ACTIVATION_KEY }}' -e "ENV_NODE_ADDR=${NODE_ADDR}" signatory-test
+        run: docker run -e 'ENV_SECRET_KEY=${{ secrets.ENV_SECRET_KEY }}' -e "ENV_NODE_ADDR=${{ matrix.testnet_endpoints }}" signatory-test

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # To add a new testnet endpoint check integration-tests/README.md
         testnet_endpoints:
           - https://ghostnet.ecadinfra.com
           - https://jakartanet.ecadinfra.com

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # To add a new testnet endpoint check integration-tests/README.md
         testnet_endpoints:
           - https://ghostnet.ecadinfra.com
           - https://jakartanet.ecadinfra.com

--- a/integration_test/Dockerfile
+++ b/integration_test/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.18-alpine
-ARG TEZOS_CLIENT_VERSION=v13.0-1
+ARG TEZOS_CLIENT_VERSION=v14.0
 
 RUN apkArch="$(apk --print-arch)" && \
 	case "$apkArch" in \

--- a/integration_test/Dockerfile
+++ b/integration_test/Dockerfile
@@ -1,5 +1,4 @@
 FROM golang:1.18-alpine
-ARG TEZOS_CLIENT_VERSION=v14.0
 
 RUN apkArch="$(apk --print-arch)" && \
 	case "$apkArch" in \
@@ -11,13 +10,13 @@ RUN apkArch="$(apk --print-arch)" && \
 		*) echo >&2 "error: unsupported architecture '$apkArch'"; exit 1 \
 			;; \
 	esac && \
-	wget -O /usr/local/bin/tezos-client https://github.com/serokell/tezos-packaging/releases/download/${TEZOS_CLIENT_VERSION}/tezos-client${TEZOS_CLIENT_ARCH} && chmod a+x /usr/local/bin/tezos-client
+	wget -O /usr/local/bin/tezos-client https://github.com/serokell/tezos-packaging/releases/latest/download/tezos-client${TEZOS_CLIENT_ARCH} && chmod a+x /usr/local/bin/tezos-client
 RUN apk add --no-cache linux-headers gcc musl-dev
 
 WORKDIR /app
 COPY . .
 RUN go mod download all
-ENV ENV_NODE_ADDR=https://ithacanet.ecadinfra.com
+ENV ENV_NODE_ADDR=https://ghostnet.ecadinfra.com
 ENV TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER=Y
 
 ENTRYPOINT [ "/bin/sh", "-c" ]

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -21,6 +21,3 @@ from https://teztnets.xyz/jakartanet-faucet. The key must be activated using
 | ENV_ACTIVATION_KEY |                                 | Activation (faucet) key json. Used to generate private key.         |
 | ENV_SECRET_KEY     |                                 | Private key in Tezos Base58 format. Overrides `ENV_ACTIVATION_KEY`. |
 | ENV_NODE_ADDR      | https://rpc.jakartanet.teztnets.xyz | Testnet node                                                        |
-
-## Add new testnet endpoint in Github CI
-To add a new testnet to the `testnet_endpoints` list in `.github/workflows/integration-tests.yaml` you also need to upgrade the `TEZOS_CLIENT_VERSION` in `integration_test/Dockerfile`

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -21,3 +21,6 @@ from https://teztnets.xyz/jakartanet-faucet. The key must be activated using
 | ENV_ACTIVATION_KEY |                                 | Activation (faucet) key json. Used to generate private key.         |
 | ENV_SECRET_KEY     |                                 | Private key in Tezos Base58 format. Overrides `ENV_ACTIVATION_KEY`. |
 | ENV_NODE_ADDR      | https://rpc.jakartanet.teztnets.xyz | Testnet node                                                        |
+
+## Add new testnet endpoint in Github CI
+To add a new testnet to the `testnet_endpoints` list in `.github/workflows/integration-tests.yaml` we also need to make sure to fund the wallet `tz1hwrfjdR4yeWrzcpKA9PJHJxea58ZUDogM` with some XTZ on the new testnet

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -21,3 +21,6 @@ from https://teztnets.xyz/jakartanet-faucet. The key must be activated using
 | ENV_ACTIVATION_KEY |                                 | Activation (faucet) key json. Used to generate private key.         |
 | ENV_SECRET_KEY     |                                 | Private key in Tezos Base58 format. Overrides `ENV_ACTIVATION_KEY`. |
 | ENV_NODE_ADDR      | https://rpc.jakartanet.teztnets.xyz | Testnet node                                                        |
+
+## Add new testnet endpoint in Github CI
+To add a new testnet to the `testnet_endpoints` list in `.github/workflows/integration-tests.yaml` you also need to upgrade the `TEZOS_CLIENT_VERSION` in `integration_test/Dockerfile`


### PR DESCRIPTION
Closes #235  
This PR uses GH Action matrix strategy to execute integration tests parallelly against all testnets

## Test Plan
Tested the changes in this MR in this GH Action run https://github.com/ecadlabs/signatory/actions/runs/2883025448

![Screenshot from 2022-08-18 16-07-57](https://user-images.githubusercontent.com/22307776/185415630-bb4d165d-e964-4dc5-9818-77d63fe8c624.png)
