### PR TITLE
Return correct error message for denied operation kinds and request kinds

### DIFF
--- a/pkg/signatory/signatory.go
+++ b/pkg/signatory/signatory.go
@@ -170,7 +170,7 @@ func matchFilter(policy *Policy, req *SignRequest, msg tezos.UnsignedMessage) er
 	}
 
 	if !allowed {
-		return fmt.Errorf("request kind `%s' is not allowed", kind)
+		return fmt.Errorf("operation `%s' is not allowed", kind)
 	}
 
 	if ops, ok := msg.(*tezos.GenericOperationRequest); ok {
@@ -184,7 +184,7 @@ func matchFilter(policy *Policy, req *SignRequest, msg tezos.UnsignedMessage) er
 				}
 			}
 			if !allowed {
-				return fmt.Errorf("operation `%s' is not allowed", kind)
+				return fmt.Errorf("request kind `%s' is not allowed", kind)
 			}
 		}
 	}

--- a/pkg/signatory/signatory_test.go
+++ b/pkg/signatory/signatory_test.go
@@ -78,7 +78,7 @@ func TestPolicy(t *testing.T) {
 				AllowedKinds:      []string{"endorsement", "seed_nonce_revelation", "activate_account", "ballot", "reveal", "transaction", "origination", "delegation"},
 				LogPayloads:       true,
 			},
-			expected: "request kind `block' is not allowed",
+			expected: "operation `block' is not allowed",
 		},
 		{
 			title: "endorsement ok",
@@ -97,7 +97,7 @@ func TestPolicy(t *testing.T) {
 				AllowedKinds:      []string{"endorsement", "seed_nonce_revelation", "activate_account", "ballot", "reveal", "transaction", "origination", "delegation"},
 				LogPayloads:       true,
 			},
-			expected: "request kind `endorsement' is not allowed",
+			expected: "operation `endorsement' is not allowed",
 		},
 		{
 			title: "generic ok",
@@ -116,7 +116,7 @@ func TestPolicy(t *testing.T) {
 				AllowedKinds:      []string{"endorsement", "seed_nonce_revelation", "activate_account", "ballot", "reveal", "origination", "delegation"},
 				LogPayloads:       true,
 			},
-			expected: "request kind `generic' is not allowed",
+			expected: "operation `generic' is not allowed",
 		},
 		{
 			title: "delegation ok",
@@ -135,7 +135,7 @@ func TestPolicy(t *testing.T) {
 				AllowedKinds:      []string{"endorsement", "seed_nonce_revelation", "activate_account", "ballot", "reveal", "origination"},
 				LogPayloads:       true,
 			},
-			expected: "operation `delegation' is not allowed",
+			expected: "request kind `delegation' is not allowed",
 		},
 		{
 			title: "origination ok",
@@ -154,7 +154,7 @@ func TestPolicy(t *testing.T) {
 				AllowedKinds:      []string{"endorsement", "seed_nonce_revelation", "activate_account", "ballot", "reveal", "transaction", "delegation"},
 				LogPayloads:       true,
 			},
-			expected: "operation `origination' is not allowed",
+			expected: "request kind `origination' is not allowed",
 		},
 		{
 			title: "reveal ok",
@@ -173,7 +173,7 @@ func TestPolicy(t *testing.T) {
 				AllowedKinds:      []string{"endorsement", "seed_nonce_revelation", "activate_account", "ballot", "transaction", "origination", "delegation"},
 				LogPayloads:       true,
 			},
-			expected: "operation `reveal' is not allowed",
+			expected: "request kind `reveal' is not allowed",
 		},
 		{
 			title: "transaction ok",
@@ -192,7 +192,7 @@ func TestPolicy(t *testing.T) {
 				AllowedKinds:      []string{"endorsement", "seed_nonce_revelation", "activate_account", "ballot", "reveal", "origination", "delegation"},
 				LogPayloads:       true,
 			},
-			expected: "operation `transaction' is not allowed",
+			expected: "request kind `transaction' is not allowed",
 		},
 	}
 


### PR DESCRIPTION
Signatory is mixing up the error messages for denied operations and request kinds. The error message should refer to the homonymous list name 

For example if I remove the `generic` from `allowed_operations` in the config file
```yaml
allowed_operations:
  - generic
  - block
  - endorsement
  - preendorsement
```

I get 
```
request kind `generic' is not allowed
```

When I remove `transaction` from `allowed_kinds`
```yaml
allowed_kinds:
  - reveal
  - transaction
  - delegation
```

I get
```
operation `transaction' is not allowed
```