### PR TITLE
Rename tezos-client binaries to octez-client

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -7,25 +7,25 @@ title: CLI
 
 To import a secret key, we will use the `signatory-cli import` command.
 
-## Generating a key using tezos-client
+## Generating a key using octez-client
 
 This is not the only way to generate keys to import in signatory. Any existing key can be imported in the vaults via signatory if the vault supports the key curve.
 
 ```bash
-% tezos-client gen keys import-p256 -s p256 --encrypted
+% octez-client gen keys import-p256 -s p256 --encrypted
 Enter password to encrypt your key:
 Confirm password:
 ```
 
 ```bash
-% tezos-client list known addresses
+% octez-client list known addresses
 import-p256: tz3gxd1y7FdVJ81vzvuACcVjAc4ewXARQkLo (encrypted sk known)
 ```
 
-The encrypted private key can be obtained from the `.tezos-client/` directory
+The encrypted private key can be obtained from the `.octez-client/` directory
 
 ```bash
-% cat ~/.tezos-client/secret_keys
+% cat ~/.octez-client/secret_keys
 [ { "name": "import-p256",
     "value":
       "encrypted:p2esk**********************************************************" }]
@@ -46,7 +46,7 @@ INFO[0007] Successfully imported                         key_id="https://forimpo
 
 If the import is successful, the `signatory-cli` will report the PKH (`tz3gxd1y7FdVJ81vzvuACcVjAc4ewXARQkLo` in the above example) of your newly imported secret which in turn can be used in the config YAML to add the policies.
 
-**Note:** The PKH from Signatory and the PKH from `tezos-client list known addresess` command must be the same.
+**Note:** The PKH from Signatory and the PKH from `octez-client list known addresess` command must be the same.
 
 Name of the key can also be provided with the import command.
 

--- a/integration_test/Dockerfile
+++ b/integration_test/Dockerfile
@@ -10,7 +10,7 @@ RUN apkArch="$(apk --print-arch)" && \
 		*) echo >&2 "error: unsupported architecture '$apkArch'"; exit 1 \
 			;; \
 	esac && \
-	wget -O /usr/local/bin/tezos-client https://github.com/serokell/tezos-packaging/releases/latest/download/tezos-client${TEZOS_CLIENT_ARCH} && chmod a+x /usr/local/bin/tezos-client
+	wget -O /usr/local/bin/octez-client https://github.com/serokell/tezos-packaging/releases/latest/download/octez-client${TEZOS_CLIENT_ARCH} && chmod a+x /usr/local/bin/octez-client
 RUN apk add --no-cache linux-headers gcc musl-dev
 
 WORKDIR /app

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -1,7 +1,7 @@
 # Integration test
 
 The test ensures that Signatory can perform an authenticated sign operations
-while assisting `tezos-client`.
+while assisting `octez-client`.
 
 From the project tree root
 
@@ -12,7 +12,7 @@ docker run -e 'ENV_ACTIVATION_KEY={...}' signatory-test
 
 where `ENV_ACTIVATION_KEY` is a contents of an activation JSON key file obtained
 from https://teztnets.xyz/jakartanet-faucet. The key must be activated using
-`tezos-client activate account` command.
+`octez-client activate account` command.
 
 ## Environment variables
 

--- a/integration_test/signatory_test.go
+++ b/integration_test/signatory_test.go
@@ -177,24 +177,24 @@ func TestSignatory(t *testing.T) {
 		dir := "./authenticated-tezos-client"
 		os.Mkdir(dir, 0777)
 		// initialize client
-		require.NoError(t, logExec(t, "tezos-client", "--base-dir", dir, "--endpoint", epAddr, "config", "init"))
+		require.NoError(t, logExec(t, "octez-client", "--base-dir", dir, "--endpoint", epAddr, "config", "init"))
 		// import key
-		require.NoError(t, logExec(t, "tezos-client", "--base-dir", dir, "import", "secret", "key", userName, "http://"+srv.Addr+"/"+pub))
+		require.NoError(t, logExec(t, "octez-client", "--base-dir", dir, "import", "secret", "key", userName, "http://"+srv.Addr+"/"+pub))
 		// add authentication key
-		require.NoError(t, logExec(t, "tezos-client", "--base-dir", dir, "import", "secret", "key", authKeyName, "unencrypted:"+authPriv))
+		require.NoError(t, logExec(t, "octez-client", "--base-dir", dir, "import", "secret", "key", authKeyName, "unencrypted:"+authPriv))
 		// create transaction
-		require.NoError(t, logExec(t, "tezos-client", "--base-dir", dir, "transfer", "0.01", "from", userName, "to", "tz1burnburnburnburnburnburnburjAYjjX", "--burn-cap", "0.06425"))
+		require.NoError(t, logExec(t, "octez-client", "--base-dir", dir, "transfer", "0.01", "from", userName, "to", "tz1burnburnburnburnburnburnburjAYjjX", "--burn-cap", "0.06425"))
 	})
 
 	t.Run("NoAuth", func(t *testing.T) {
 		dir := "./unauthenticated-tezos-client"
 		os.Mkdir(dir, 0777)
 		// initialize client
-		require.NoError(t, logExec(t, "tezos-client", "--base-dir", dir, "--endpoint", epAddr, "config", "init"))
+		require.NoError(t, logExec(t, "octez-client", "--base-dir", dir, "--endpoint", epAddr, "config", "init"))
 		// import key
-		require.NoError(t, logExec(t, "tezos-client", "--base-dir", dir, "import", "secret", "key", userName, "http://"+srv.Addr+"/"+pub))
+		require.NoError(t, logExec(t, "octez-client", "--base-dir", dir, "import", "secret", "key", userName, "http://"+srv.Addr+"/"+pub))
 		// create transaction
-		require.Error(t, logExec(t, "tezos-client", "--base-dir", dir, "transfer", "0.01", "from", userName, "to", "tz1burnburnburnburnburnburnburjAYjjX", "--burn-cap", "0.06425"))
+		require.Error(t, logExec(t, "octez-client", "--base-dir", dir, "transfer", "0.01", "from", userName, "to", "tz1burnburnburnburnburnburnburjAYjjX", "--burn-cap", "0.06425"))
 	})
 
 	srv.Shutdown(context.Background())


### PR DESCRIPTION
Starting from Octez v15 the `tezos-*` binaries (e.g. `tezos-client`, `tezos-node` etc) were all renamed to `octez-*`.

This PR updates Signatory integration tests to use `octez-client` and updates the references in the READMEs