### PR TITLE
Import secrets are received without any terminal history

### DIFF
--- a/cmd/commands/import.go
+++ b/cmd/commands/import.go
@@ -17,7 +17,7 @@ func NewImportCommand(c *Context) *cobra.Command {
 	)
 
 	importCmd := &cobra.Command{
-		Use:   "import <secret-key>",
+		Use:   "import <flags>",
 		Short: "Import Tezos private keys (edsk..., spsk..., p2sk...)",
 		Args:  cobra.MinimumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/commands/import.go
+++ b/cmd/commands/import.go
@@ -17,7 +17,7 @@ func NewImportCommand(c *Context) *cobra.Command {
 	)
 
 	importCmd := &cobra.Command{
-		Use:   "import <flags>",
+		Use:   "import [flags]",
 		Short: "Import Tezos private keys (edsk..., spsk..., p2sk...)",
 		Args:  cobra.MinimumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -32,7 +32,7 @@ func NewImportCommand(c *Context) *cobra.Command {
 			} else {
 				passCB = func() ([]byte, error) {
 					fmt.Println()
-					fmt.Print("Enter Password: ")
+					fmt.Print("This key is encrypted, enter the password: ")
 					return terminal.ReadPassword(int(syscall.Stdin))
 				}
 			}

--- a/cmd/commands/import.go
+++ b/cmd/commands/import.go
@@ -19,7 +19,7 @@ func NewImportCommand(c *Context) *cobra.Command {
 	importCmd := &cobra.Command{
 		Use:   "import <secret-key>",
 		Short: "Import Tezos private keys (edsk..., spsk..., p2sk...)",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.MinimumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			o, err := utils.ParseMap(opt, ':', ',')
 			if err != nil {
@@ -41,11 +41,19 @@ func NewImportCommand(c *Context) *cobra.Command {
 				options[k] = v
 			}
 
-			for _, key := range args {
-				_, err := c.signatory.Import(c.Context, vaultName, key, passCB, options)
-				if err != nil {
-					return err
-				}
+			fmt.Print("Enter secret key: ")
+			key, err := terminal.ReadPassword(int(syscall.Stdin))
+			if err != nil {
+				return err
+			}
+			fmt.Println()
+			if len(key) == 0 {
+				return fmt.Errorf("enter a valid secret key")
+			}
+
+			_, err = c.signatory.Import(c.Context, vaultName, string(key), passCB, options)
+			if err != nil {
+				return err
 			}
 
 			return nil

--- a/cmd/commands/import.go
+++ b/cmd/commands/import.go
@@ -31,6 +31,7 @@ func NewImportCommand(c *Context) *cobra.Command {
 				passCB = func() ([]byte, error) { return []byte(password), nil }
 			} else {
 				passCB = func() ([]byte, error) {
+					fmt.Println()
 					fmt.Print("Enter Password: ")
 					return terminal.ReadPassword(int(syscall.Stdin))
 				}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,9 +37,10 @@ A private key can be imported into any of the backend vaults (except: AWS & ledg
 If you import an encrypted key, the `signatory-cli` command will prompt you for the password.
 
 ```bash
-% ./signatory-cli import -c ./azure.yaml --base-dir ./ --vault azure p2esk*****************
+% ./signatory-cli import -c ./azure.yaml --base-dir ./ --vault azure
 INFO[0000] Initializing vault                            vault=azure vault_name=azure
-Enter Password: 
+Enter secret key: 
+Enter Password:
 INFO[0002] Requesting import operation                   pkh=tz3gxd1y7FdVJ81vzvuACcVjAc4ewXARQkLo vault=Azure vault_name="https://forimport.vault.azure.net/"
 INFO[0007] Successfully imported                         key_id="https://forimport.vault.azure.net/keys/signatory-imported-2CsWhgGqeRdkEiA0LFm3WyN5DxS/9d2266b388734ef0b14203e0943465d7" pkh=tz3gxd1y7FdVJ81vzvuACcVjAc4ewXARQkLo vault=Azure vault_name="https://forimport.vault.azure.net/"
 ```
@@ -51,8 +52,9 @@ If the import is successful, the `signatory-cli` will report the PKH (`tz3gxd1y7
 Name of the key can also be provided with the import command.
 
 ```bash
-% ./signatory-cli import -c ./azure.yaml --base-dir ./ --vault azure p2esk********************************** -o "name":test-name
+% ./signatory-cli import -c ./azure.yaml --base-dir ./ --vault azure -o "name":test-name
 INFO[0000] Initializing vault                            vault=azure vault_name=azure
+Enter secret key: 
 Enter Password: 
 INFO[0003] Requesting import operation                   pkh=tz2PpBJj8utBU3Nxu7vexbdJVTcRxYfkfqcV vault=Azure vault_name="https://forimport.vault.azure.net/"
 INFO[0009] Successfully imported                         key_id="https://forimport.vault.azure.net/keys/test-name/f503f20b309e4c8ea57982bd9736c412" pkh=tz2PpBJj8utBU3Nxu7vexbdJVTcRxYfkfqcV vault=Azure vault_name="https://forimport.vault.azure.net/"

--- a/docs/gcp_kms.md
+++ b/docs/gcp_kms.md
@@ -110,8 +110,10 @@ Users can generate a private key in an air gap environment and then import it in
 2. Use the below command to import the generated private into GCP Key Management. Only `Elliptic Curve P-256 - SHA256` `Digest` is supported now. Below sample key is taken from `signatory/docs/yubihsm.md`
 
 ```sh
-% ./signatory-cli import -c signatory.yaml --vault kms p2esk28hoUE2J88QNFj2aDX2pjzL7wcVh2g8tkEwtWWguby9M3FHUgSbzvF2Sd7wQ4Kd8crFwvto6gF3otcBuo4T
+% ./signatory-cli import -c signatory.yaml --vault kms
 
 INFO[0000] Initializing vault                            vault=cloudkms vault_name=kms
+Enter secret key: 
+Enter Password: 
 Enter Password: INFO[0002] Requesting import operation                   pkh=tz3be5v4ZWL3zQYUZoLWJQy8P3H6RJryVVXn vault=CloudKMS vault_name=projects/signatory-testing/locations/europe-north1/keyRings/sign-ring
 INFO[0008] Successfully imported                         key_id=projects/signatory-testing/locations/europe-north1/keyRings/sign-ring/cryptoKeys/signatory-imported-215FwcXxhLdlr9IYwzA31vwANmy/cryptoKeyVersions/1 pkh=tz3be5v4ZWL3zQYUZoLWJQy8P3H6RJryVVXn vault=CloudKMS vault_name=projects/signatory-testing/locations/europe-north1/keyRings/sign-ring

--- a/docs/start.md
+++ b/docs/start.md
@@ -211,8 +211,10 @@ Flags:
       --vault string      Vault name for importing
 
 Global Flags:
-  -c, --config string   Config file path (default "signatory.yaml")
-      --log string      Log level: [error, warn, info, debug, trace] (default "info")
+      --base-dir string   Base directory. Takes priority over one specified in config
+  -c, --config string     Config file path (default "/etc/signatory.yaml")
+      --json-log          Use JSON structured logs
+      --log string        Log level: [error, warn, info, debug, trace] (default "info")
 ```
 
 ### Import a private key

--- a/docs/yubihsm.md
+++ b/docs/yubihsm.md
@@ -129,13 +129,15 @@ vaults:
 To import a secret key, we take the secret key from the above JSON examples. Do not include the "encrypted:" or "unencrypted:" prefix.
 
 ```bash
-signatory-cli import --config ./signatory.yaml --vault yubi edsk2rKA8YEExg9Zo2qNPiQnnYheF1DhqjLVmfKdxiFfu5GyGRZRnb
+signatory-cli import --config ./signatory.yaml --vault yubi
 ```
 
 If the import is successful, the `signatory-cli` will report the PKH of your newly imported secret:
 
 ```bash
 INFO[0000] Initializing vault                            vault=yubihsm vault_name=yubi
+Enter secret key: 
+Enter Password:
 INFO[0000] Requesting import operation                   pkh=tz1SBhzLDp9Jvg98ztMZMstaKbAENmzRd4Y7 vault=YubiHSM vault_name="localhost:12345/1"
 INFO[0000] Successfully imported                         key_id=0cf8 pkh=tz1SBhzLDp9Jvg98ztMZMstaKbAENmzRd4Y7 vault=YubiHSM vault_name="localhost:12345/1"
 ```

--- a/pkg/cryptoutils/cypto_test.go
+++ b/pkg/cryptoutils/cypto_test.go
@@ -2,7 +2,6 @@ package cryptoutils
 
 import (
 	"crypto/elliptic"
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -25,7 +24,6 @@ func TestCryptoCanonizeSignature(t *testing.T) {
 	t.Run("Without curve", func(t *testing.T) {
 		require.NotPanics(t, func() { nocurve = CanonizeSignature(sig).(*ECDSASignature) })
 		require.Nil(t, nocurve.Curve)
-		fmt.Println("Nocurve Signature: ", *nocurve)
 		sig.Curve = elliptic.P256()
 	})
 

--- a/pkg/tezos/key.go
+++ b/pkg/tezos/key.go
@@ -90,7 +90,6 @@ func ParsePrivateKey(data string, passFunc PassphraseFunc) (priv cryptoutils.Pri
 	if err != nil {
 		return
 	}
-
 	// See https://github.com/murbard/pytezos/blob/master/pytezos/crypto.py#L67
 	if unencPrefix, ok := isEncrypted(prefix); ok {
 		// Decrypt
@@ -145,7 +144,6 @@ func ParsePrivateKey(data string, passFunc PassphraseFunc) (priv cryptoutils.Pri
 		}
 		return ed25519.PrivateKey(pl), nil
 	}
-
 	return nil, ErrPrivateKey
 }
 

--- a/pkg/tezos/key.go
+++ b/pkg/tezos/key.go
@@ -98,6 +98,7 @@ func ParsePrivateKey(data string, passFunc PassphraseFunc) (priv cryptoutils.Pri
 			return nil, ErrPassphrase
 		}
 		passphrase, err := passFunc()
+		fmt.Println()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tezos/key.go
+++ b/pkg/tezos/key.go
@@ -97,7 +97,6 @@ func ParsePrivateKey(data string, passFunc PassphraseFunc) (priv cryptoutils.Pri
 			return nil, ErrPassphrase
 		}
 		passphrase, err := passFunc()
-		fmt.Println()
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**Existing behaviour:**
Secret key is part of the import cli command and available in cli history.
**Behaviour with this fix**
Secret key is not part of import cli. It is received fro user like a password. Not visible in cli history.