### PR TITLE
fixed broken link to approve list service on remote policy page

### DIFF
--- a/docs/remote_policy.md
+++ b/docs/remote_policy.md
@@ -71,4 +71,4 @@ Just the HTTP status code is inspected. The sign operation is allowed if the ser
 
 ## Reference implementation
 
-See [Approve List Service](https://github.com/ecadlabs/signatory/tree/main/cmd/approve-list-svc)
+See [Approve List Service](/cmd/approve-list-svc/README.md)

--- a/docs/remote_policy.md
+++ b/docs/remote_policy.md
@@ -71,4 +71,4 @@ Just the HTTP status code is inspected. The sign operation is allowed if the ser
 
 ## Reference implementation
 
-See [Approve List Service](/cmd/approve-list-svc/README.md)
+See [Approve List Service](https://github.com/ecadlabs/signatory/tree/main/cmd/approve-list-svc)

--- a/docs/remote_policy.md
+++ b/docs/remote_policy.md
@@ -71,4 +71,4 @@ Just the HTTP status code is inspected. The sign operation is allowed if the ser
 
 ## Reference implementation
 
-See [Approve List Service](/cmd/approve-list-svc)
+See [Approve List Service](https://github.com/ecadlabs/signatory/tree/main/cmd/approve-list-svc)


### PR DESCRIPTION
pointed to the source in the repo instead of trying to invoke the command with the link.