### PR TITLE
JWT library updated and code changes to match the new version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/enceve/crypto v0.0.0-20160707101852-34d48bb93815 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/golang-jwt/jwt/v5 v5.0.0-rc.1
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.11.2 h1:q3SHpufmypg+erIExEKUmsgmhDTyhcJ38oeKGACXohU=
 github.com/go-playground/validator/v10 v10.11.2/go.mod h1:NieE624vt4SCTJtD87arVLvdmjPAeV8BQlHtMnw9D7s=
+github.com/golang-jwt/jwt/v5 v5.0.0-rc.1 h1:tDQ1LjKga657layZ4JLsRdxgvupebc0xuPwRNuTfUgs=
+github.com/golang-jwt/jwt/v5 v5.0.0-rc.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=


### PR DESCRIPTION
Tests done:
```
$ ./signatory-cli import -c signatory.yaml --vault azure
INFO[0000] Initializing vault                            vault=azure vault_name=azure
Enter secret key: 
INFO[0069] Requesting import operation                   pkh=tz3Yuvqwo9RnBMNip7qPfyHNz5xMf5DJzX7X vault=Azure vault_name="https://jwt-test.vault.azure.net/"
INFO[0074] Successfully imported                         key_id="https://jwt-test.vault.azure.net/keys/signatory-imported-2N37LD2DByOd84RsCbLM0IayLln/aba9ddf969984e4a8b4fa49dde63febe" pkh=tz3Yuvqwo9RnBMNip7qPfyHNz5xMf5DJzX7X vault=Azure vault_name="https://jwt-test.vault.azure.net/"
```
```
$ ./signatory-cli list -c signatory.yaml                                       
INFO[0000] Initializing vault                            vault=azure vault_name=azure
Public Key Hash:    tz3Y6yv1cDppGhtt3DHF7BgCdZQuctqNptqa
Vault:              Azure
ID:                 https://jwt-test.vault.azure.net/keys/jwt-test-key/dd0cab8beeda432fb225769254c7750b
Active:             false

Public Key Hash:    tz3Yuvqwo9RnBMNip7qPfyHNz5xMf5DJzX7X
Vault:              Azure
ID:                 https://jwt-test.vault.azure.net/keys/signatory-imported-2N37LD2DByOd84RsCbLM0IayLln/aba9ddf969984e4a8b4fa49dde63febe
Active:             false
```
```
INFO[0541] GET /authorized_keys                          duration="63.667µs" hostname="localhost:6732" method=GET path=/authorized_keys start_time="2023-03-16T15:54:12+05:30" status=200
INFO[0541] Requesting signing operation                  ops="map[reveal:1 transaction:1]" ops_total=2 pkh=tz3Yuvqwo9RnBMNip7qPfyHNz5xMf5DJzX7X request=generic vault=Azure vault_name="https://jwt-test.vault.azure.net/"
INFO[0541] About to sign raw bytes                       ops="map[reveal:1 transaction:1]" ops_total=2 pkh=tz3Yuvqwo9RnBMNip7qPfyHNz5xMf5DJzX7X raw=03f590fb8a06946c82f52e552166e118c712c3669b34a104c81b2f4c2317948da96b028a09fffebc5c9443232f92ad353e876e5b596f89e902e6c9ac07e8070002035c6eaca1de6fe5d5f55ebb9b426ec71096491019bdc3ad1a3375dbd36851d8b36c028a09fffebc5c9443232f92ad353e876e5b596f898402e7c9ac07e907950280ade20400021ce31af23d8601495e794a087dd07fab948da17d00 request=generic vault=Azure vault_name="https://jwt-test.vault.azure.net/"
INFO[0544] Signed generic successfully                   ops="map[reveal:1 transaction:1]" ops_total=2 pkh=tz3Yuvqwo9RnBMNip7qPfyHNz5xMf5DJzX7X request=generic vault=Azure vault_name="https://jwt-test.vault.azure.net/"
INFO[0544] POST /keys/tz3Yuvqwo9RnBMNip7qPfyHNz5xMf5DJzX7X  duration=2.846795292s hostname="localhost:6732" method=POST path=/keys/tz3Yuvqwo9RnBMNip7qPfyHNz5xMf5DJzX7X start_time="2023-03-16T15:54:12+05:30" status=200
```