### PR TITLE
Update signatory_test.go - use wait 1 cycle option

### DIFF
--- a/integration_test/signatory_test.go
+++ b/integration_test/signatory_test.go
@@ -183,7 +183,7 @@ func TestSignatory(t *testing.T) {
 		// add authentication key
 		require.NoError(t, logExec(t, "octez-client", "--base-dir", dir, "import", "secret", "key", authKeyName, "unencrypted:"+authPriv))
 		// create transaction
-		require.NoError(t, logExec(t, "octez-client", "--base-dir", dir, "transfer", "0.01", "from", userName, "to", "tz1burnburnburnburnburnburnburjAYjjX", "--burn-cap", "0.06425"))
+		require.NoError(t, logExec(t, "octez-client", "-w", "1", "--base-dir", dir, "transfer", "0.01", "from", userName, "to", "tz1burnburnburnburnburnburnburjAYjjX", "--burn-cap", "0.06425"))
 	})
 
 	t.Run("NoAuth", func(t *testing.T) {
@@ -194,7 +194,7 @@ func TestSignatory(t *testing.T) {
 		// import key
 		require.NoError(t, logExec(t, "octez-client", "--base-dir", dir, "import", "secret", "key", userName, "http://"+srv.Addr+"/"+pub))
 		// create transaction
-		require.Error(t, logExec(t, "octez-client", "--base-dir", dir, "transfer", "0.01", "from", userName, "to", "tz1burnburnburnburnburnburnburjAYjjX", "--burn-cap", "0.06425"))
+		require.Error(t, logExec(t, "octez-client",  "-w", "1", "--base-dir", dir, "transfer", "0.01", "from", userName, "to", "tz1burnburnburnburnburnburnburjAYjjX", "--burn-cap", "0.06425"))
 	})
 
 	srv.Shutdown(context.Background())


### PR DESCRIPTION
add wait 1 cycle option to octez-client transfer commands in an effort to make the test less flaky