### PR TITLE
Fix Docker Hub authentication for publishing Docker images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,7 +59,8 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      - name: Login to DockerHub
+
+      - name: Login to GHCR
         uses: docker/login-action@v2
         if: "!startsWith(github.ref, 'refs/tags/v')"
         with:
@@ -67,16 +68,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Write release-env file
-        uses: DamianReeves/write-file-action@v1.0
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
         if: startsWith(github.ref, 'refs/tags/v')
         with:
-          path: ${{ github.workspace }}/.release-env
-          contents: |
-            DOCKER_FAIL_ON_LOGIN_ERROR=true
-            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-            DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}
-            DOCKER_PASSWORD=${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: goreleaser release preview
         run: make release-preview

--- a/Makefile
+++ b/Makefile
@@ -52,15 +52,10 @@ release-preview:
 
 .PHONY: release
 release:
-	@if [ ! -f ".release-env" ]; then \
-		echo "\033[91m.release-env is required for release\033[0m";\
-		exit 1;\
-	fi
 	docker run \
 		--rm \
 		--privileged \
 		-e CGO_ENABLED=1 \
-		--env-file .release-env \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \


### PR DESCRIPTION
Fixes the Docker Hub login authentication by using the `docker/login-action@v2` GH Action.

I tested this and can confirm that we can successfully login as shown in the screenshot below
![Screenshot from 2023-06-13 20-29-11](https://github.com/ecadlabs/signatory/assets/22307776/d18710dc-006c-4525-acbc-ad979748727d)
