### PR TITLE
Integrationtest codecoverage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -163,7 +163,7 @@ jobs:
          rm -f gcp-token.json;
          rm -f service-principal.key;
          go tool covdata textfmt -i=./coverage -o=./coverage/cov.txt;
-         sed -i '' 's/\/go\/src\/github.com/github.com/g' ./coverage/cov.txt;
+         sed -i 's/\/go\/src\/github.com/github.com/g' ./coverage/cov.txt;
          go tool cover -html=./coverage/cov.txt -o=./coverage/integrationtestcoverage.html;
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -150,7 +150,6 @@ jobs:
           VAULT_GCP_KEYRING: ${{ secrets.INTEGRATIONTEST_VAULT_GCP_KEYRING }}
           VAULT_GCP_LOCATION: ${{ secrets.INTEGRATIONTEST_VAULT_GCP_LOCATION }}
           VAULT_GCP_TZ3: ${{ secrets.INTEGRATIONTEST_VAULT_GCP_TZ3 }}
-
         run: >
          cd integration_test;
          export ARCH=amd64;
@@ -163,3 +162,9 @@ jobs:
          docker compose kill;
          rm -f gcp-token.json;
          rm -f service-principal.key;
+         go tool covdata textfmt -i=./coverage -o=./coverage/cov.txt;
+         go tool cover -html=./coverage/cov.txt -o=./coverage/integrationtestcoverage.html;
+      - uses: actions/upload-artifact@v3
+        with:
+          name: integration-test-coverage
+          path: ./coverage/integrationtestcoverage.html

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -163,8 +163,9 @@ jobs:
          rm -f gcp-token.json;
          rm -f service-principal.key;
          go tool covdata textfmt -i=./coverage -o=./coverage/cov.txt;
+         sed -i '' 's/\/go\/src\/github.com/github.com/g' ./coverage/cov.txt;
          go tool cover -html=./coverage/cov.txt -o=./coverage/integrationtestcoverage.html;
       - uses: actions/upload-artifact@v3
         with:
-          name: integration-test-coverage
+          name: integrationtest-coverage-env${{ matrix.testenvs }}
           path: ./coverage/integrationtestcoverage.html

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -168,4 +168,4 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: integrationtest-coverage-env${{ matrix.testenvs }}
-          path: ./coverage/integrationtestcoverage.html
+          path: ./integration_test/coverage/integrationtestcoverage.html

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,7 @@ builds:
       - CGO_ENABLED=1
       - CC=gcc
       - CXX=g++
+      - '{{ if .IsSnapshot }}GOEXPERIMENT=coverageredesign{{ end }}'
     main: ./cmd/signatory/main.go
     ldflags:
       - '-X github.com/ecadlabs/signatory/pkg/metrics.GitRevision={{.Version}}'
@@ -14,12 +15,16 @@ builds:
       - linux
     goarch:
       - amd64
+    flags:
+      - '{{ if .IsSnapshot }}-cover{{ end }}'
+
   - id: signatory-cli-linux-amd
     binary: signatory-cli
     env:
       - CGO_ENABLED=1
       - CC=gcc
       - CXX=g++
+      - '{{ if .IsSnapshot }}GOEXPERIMENT=coverageredesign{{ end }}'
     main: ./cmd/signatory-cli/main.go
     ldflags:
       - '-X github.com/ecadlabs/signatory/pkg/metrics.GitRevision={{.Version}}'
@@ -28,6 +33,8 @@ builds:
       - linux
     goarch:
       - amd64
+    flags:
+      - '{{ if .IsSnapshot }}-cover{{ end }}'
 
   - id: signatory-linux-arm64
     binary: signatory
@@ -35,6 +42,7 @@ builds:
       - CGO_ENABLED=1
       - CC=aarch64-linux-gnu-gcc
       - CXX=aarch64-linux-gnu-g++
+      - '{{ if .IsSnapshot }}GOEXPERIMENT=coverageredesign{{ end }}'
     main: ./cmd/signatory/main.go
     ldflags:
       - '-X github.com/ecadlabs/signatory/pkg/metrics.GitRevision={{.Version}}'
@@ -43,12 +51,16 @@ builds:
       - linux
     goarch:
       - arm64
+    flags:
+      - '{{ if .IsSnapshot }}-cover{{ end }}'
+
   - id: signatory-cli-linux-arm64
     binary: signatory-cli
     env:
       - CGO_ENABLED=1
       - CC=aarch64-linux-gnu-gcc
       - CXX=aarch64-linux-gnu-g++
+      - '{{ if .IsSnapshot }}GOEXPERIMENT=coverageredesign{{ end }}'
     main: ./cmd/signatory-cli/main.go
     ldflags:
       - '-X github.com/ecadlabs/signatory/pkg/metrics.GitRevision={{.Version}}'
@@ -57,6 +69,8 @@ builds:
       - linux
     goarch:
       - arm64
+    flags:
+      - '{{ if .IsSnapshot }}-cover{{ end }}'
 
   - id: signatory-linux-arm
     binary: signatory
@@ -64,6 +78,7 @@ builds:
       - CGO_ENABLED=1
       - CC=arm-linux-gnueabihf-gcc
       - CXX=arm-linux-gnueabihf-g++
+      - '{{ if .IsSnapshot }}GOEXPERIMENT=coverageredesign{{ end }}'
     main: ./cmd/signatory/main.go
     ldflags:
       - '-X github.com/ecadlabs/signatory/pkg/metrics.GitRevision={{.Version}}'
@@ -75,12 +90,16 @@ builds:
     goarm:
       - '6'
       - '7'
+    flags:
+      - '{{ if .IsSnapshot }}-cover{{ end }}'
+
   - id: signatory-cli-linux-arm
     binary: signatory-cli
     env:
       - CGO_ENABLED=1
       - CC=arm-linux-gnueabihf-gcc
       - CXX=arm-linux-gnueabihf-g++
+      - '{{ if .IsSnapshot }}GOEXPERIMENT=coverageredesign{{ end }}'
     main: ./cmd/signatory-cli/main.go
     ldflags:
       - '-X github.com/ecadlabs/signatory/pkg/metrics.GitRevision={{.Version}}'
@@ -92,6 +111,8 @@ builds:
     goarm:
       - '6'
       - '7'
+    flags:
+      - '{{ if .IsSnapshot }}-cover{{ end }}'
 
 # MACOS
   - id: signatory-darwin-amd
@@ -100,6 +121,7 @@ builds:
       - CGO_ENABLED=1
       - CC=o64-clang
       - CXX=o64-clang++
+      - '{{ if .IsSnapshot }}GOEXPERIMENT=coverageredesign{{ end }}'
     main: ./cmd/signatory/main.go
     ldflags:
       - '-X github.com/ecadlabs/signatory/pkg/metrics.GitRevision={{.Version}}'
@@ -108,12 +130,16 @@ builds:
       - darwin
     goarch:
       - amd64
+    flags:
+      - '{{ if .IsSnapshot }}-cover{{ end }}'
+
   - id: signatory-cli-darwing-amd
     binary: signatory-cli
     env:
       - CGO_ENABLED=1
       - CC=o64-clang
       - CXX=o64-clang++
+      - '{{ if .IsSnapshot }}GOEXPERIMENT=coverageredesign{{ end }}'
     main: ./cmd/signatory-cli/main.go
     ldflags:
       - '-X github.com/ecadlabs/signatory/pkg/metrics.GitRevision={{.Version}}'
@@ -122,6 +148,8 @@ builds:
       - darwin
     goarch:
       - amd64
+    flags:
+      - '{{ if .IsSnapshot }}-cover{{ end }}'
 
   - id: signatory-darwin-arm
     binary: signatory
@@ -129,6 +157,7 @@ builds:
       - CGO_ENABLED=1
       - CC=oa64-clang
       - CXX=oa64-clang++
+      - '{{ if .IsSnapshot }}GOEXPERIMENT=coverageredesign{{ end }}'
     main: ./cmd/signatory/main.go
     ldflags:
       - '-X github.com/ecadlabs/signatory/pkg/metrics.GitRevision={{.Version}}'
@@ -137,12 +166,16 @@ builds:
       - darwin
     goarch:
       - arm64
+    flags:
+      - '{{ if .IsSnapshot }}-cover{{ end }}'
+
   - id: signatory-cli-darwing-arm
     binary: signatory-cli
     env:
       - CGO_ENABLED=1
       - CC=oa64-clang
       - CXX=oa64-clang++
+      - '{{ if .IsSnapshot }}GOEXPERIMENT=coverageredesign{{ end }}'
     main: ./cmd/signatory-cli/main.go
     ldflags:
       - '-X github.com/ecadlabs/signatory/pkg/metrics.GitRevision={{.Version}}'
@@ -151,6 +184,8 @@ builds:
       - darwin
     goarch:
       - arm64
+    flags:
+      - '{{ if .IsSnapshot }}-cover{{ end }}'
 
 # WINDOWS
   - id: signatory-windows-amd
@@ -159,6 +194,7 @@ builds:
       - CGO_ENABLED=1
       - CC=x86_64-w64-mingw32-gcc
       - CXX=x86_64-w64-mingw32-g++
+      - '{{ if .IsSnapshot }}GOEXPERIMENT=coverageredesign{{ end }}'
     main: ./cmd/signatory/main.go
     ldflags:
       - '-X github.com/ecadlabs/signatory/pkg/metrics.GitRevision={{.Version}}'
@@ -167,12 +203,16 @@ builds:
       - windows
     goarch:
       - amd64
+    flags:
+      - '{{ if .IsSnapshot }}-cover{{ end }}'
+
   - id: signatory-cli-windows-amd
     binary: signatory-cli
     env:
       - CGO_ENABLED=1
       - CC=x86_64-w64-mingw32-gcc
       - CXX=x86_64-w64-mingw32-g++
+      - '{{ if .IsSnapshot }}GOEXPERIMENT=coverageredesign{{ end }}'
     main: ./cmd/signatory-cli/main.go
     ldflags:
       - '-X github.com/ecadlabs/signatory/pkg/metrics.GitRevision={{.Version}}'
@@ -181,6 +221,9 @@ builds:
       - windows
     goarch:
       - amd64
+    flags:
+      - '{{ if .IsSnapshot }}-cover{{ end }}'
+
 dockers:
   - ids:
       - signatory

--- a/integration_test/coverage.sh
+++ b/integration_test/coverage.sh
@@ -1,0 +1,3 @@
+#! /bin/sh
+go tool covdata textfmt -i=/opt/coverage -o=/opt/coverage/cov.txt
+go tool cover -func=/opt/coverage/cov.txt

--- a/integration_test/coverage.sh
+++ b/integration_test/coverage.sh
@@ -1,3 +1,0 @@
-#! /bin/sh
-go tool covdata textfmt -i=/opt/coverage -o=/opt/coverage/cov.txt
-go tool cover -func=/opt/coverage/cov.txt

--- a/integration_test/coverage/.gitignore
+++ b/integration_test/coverage/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/integration_test/docker-compose.yml
+++ b/integration_test/docker-compose.yml
@@ -81,8 +81,11 @@ services:
         target: /etc/gcp-token.json
       - source: az-sp-key
         target: /etc/service-principal.key
+    volumes:
+      - ./coverage:/opt/coverage     
     environment:
       - GOOGLE_APPLICATION_CREDENTIALS=/etc/gcp-token.json
+      - GOCOVERDIR=/opt/coverage
     depends_on:
       speculos:
         condition: service_healthy

--- a/integration_test/docker-compose.yml
+++ b/integration_test/docker-compose.yml
@@ -82,7 +82,8 @@ services:
       - source: az-sp-key
         target: /etc/service-principal.key
     volumes:
-      - ./coverage:/opt/coverage     
+      - ./coverage:/opt/coverage
+      - ./coverage.sh:/usr/bin/coverage
     environment:
       - GOOGLE_APPLICATION_CREDENTIALS=/etc/gcp-token.json
       - GOCOVERDIR=/opt/coverage

--- a/integration_test/docker-compose.yml
+++ b/integration_test/docker-compose.yml
@@ -83,7 +83,6 @@ services:
         target: /etc/service-principal.key
     volumes:
       - ./coverage:/opt/coverage
-      - ./coverage.sh:/usr/bin/coverage
     environment:
       - GOOGLE_APPLICATION_CREDENTIALS=/etc/gcp-token.json
       - GOCOVERDIR=/opt/coverage


### PR DESCRIPTION
this PR instruments the snapshot image builds, and uploads as artifacts code coverage reports for the integration tests. 
this PR does not merge the integration tests coverage with the existing unit test coverage, nor does it upload to code climate.  these will come in a subsequent PR