### PR TITLE
add dependabot config with separator as hyphen

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    pull-request-branch-name:
+      separator: "-"

--- a/integration_test/docker-compose.yml
+++ b/integration_test/docker-compose.yml
@@ -74,6 +74,7 @@ services:
       - ecadnet
     volumes:
       - ./.watermarks:/var/lib/signatory
+      - ./coverage:/opt/coverage
     configs:
       - source: sigy-config
         target: /etc/signatory.yaml
@@ -83,8 +84,6 @@ services:
         target: /etc/gcp-token.json
       - source: az-sp-key
         target: /etc/service-principal.key
-    volumes:
-      - ./coverage:/opt/coverage
     environment:
       - GOOGLE_APPLICATION_CREDENTIALS=/etc/gcp-token.json
       - GOCOVERDIR=/opt/coverage


### PR DESCRIPTION
the default separator "/" forms invalid image tags