### PR TITLE
bump goreleaser-cross to 1.20.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ release:
 		-e CGO_ENABLED=1 \
 		--env-file .env \
 		-v /var/run/docker.sock:/var/run/docker.sock \
-		-v $(HOME)/.docker/config.json:/root/.docker/config.json \
+		-v $(HOME)/.docker:/root/.docker \
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \
 		goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CONTAINER_TAG ?= $(shell git branch --show-current)
 COLLECTOR_PKG = github.com/ecadlabs/signatory/pkg/metrics
 
 PACKAGE_NAME          := github.com/ecadlabs/signatory
-GOLANG_CROSS_VERSION  ?= v1.20.3
+GOLANG_CROSS_VERSION  ?= v1.20.6
 
 all: signatory signatory-cli
 


### PR DESCRIPTION
the `release` build target is currently broken. 
when I run goreleaser-cross on my workstation, I repro the same build error. 
when I update my version to 1.20.6, the build gets further. 