### PR TITLE
update base image to ubuntu:22.04.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10
+FROM ubuntu:22.04.2
 RUN apt-get update
 RUN apt-get install -y curl apt-transport-https
 RUN apt-get clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:23.10
 RUN apt-get update
 RUN apt-get install -y curl apt-transport-https
 RUN apt-get clean


### PR DESCRIPTION
docker scout recommendations ghcr.io/ecadlabs/signatory:main-arm64

• Image is smaller by 1.0 MB
• Image introduces no new vulnerability but removes 11