### PR TITLE
replace slash with hyphen for valid image tags

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,18 +80,27 @@ jobs:
         run: make release-preview
         if: "!startsWith(github.ref, 'refs/tags/v')"
 
+      - name: remove slash from image tag
+        uses: mad9000/actions-find-and-replace-string@3
+        id: replaceslash
+        with:
+          source: ${{ github.head_ref || github.ref_name }}
+          find: '/'
+          replace: '-'
+        if: "!startsWith(github.ref, 'refs/tags/v')"
+
       - name: Tag Docker images appropriately
         run: >
-          docker tag ghcr.io/ecadlabs/signatory:${{ github.sha }}-amd64 ghcr.io/ecadlabs/signatory:${{ github.head_ref || github.ref_name }}-amd64;
-          docker tag ghcr.io/ecadlabs/signatory:${{ github.sha }}-arm64 ghcr.io/ecadlabs/signatory:${{ github.head_ref || github.ref_name }}-arm64;
-          docker tag ghcr.io/ecadlabs/signatory:${{ github.sha }}-armv7 ghcr.io/ecadlabs/signatory:${{ github.head_ref || github.ref_name }}-armv7;
+          docker tag ghcr.io/ecadlabs/signatory:${{ github.sha }}-amd64 ghcr.io/ecadlabs/signatory:${{ steps.replaceslash.outputs.value }}-amd64;
+          docker tag ghcr.io/ecadlabs/signatory:${{ github.sha }}-arm64 ghcr.io/ecadlabs/signatory:${{ steps.replaceslash.outputs.value }}-arm64;
+          docker tag ghcr.io/ecadlabs/signatory:${{ github.sha }}-armv7 ghcr.io/ecadlabs/signatory:${{ steps.replaceslash.outputs.value }}-armv7;
         if: "!startsWith(github.ref, 'refs/tags/v')"
 
       - name: Push Signatory preview images to GH Container Registry
         run: >
-         docker push ghcr.io/ecadlabs/signatory:${{ github.head_ref || github.ref_name }}-amd64;
-         docker push ghcr.io/ecadlabs/signatory:${{ github.head_ref || github.ref_name }}-arm64;
-         docker push ghcr.io/ecadlabs/signatory:${{ github.head_ref || github.ref_name }}-armv7;
+         docker push ghcr.io/ecadlabs/signatory:${{ steps.replaceslash.outputs.value }}-amd64;
+         docker push ghcr.io/ecadlabs/signatory:${{ steps.replaceslash.outputs.value }}-arm64;
+         docker push ghcr.io/ecadlabs/signatory:${{ steps.replaceslash.outputs.value }}-armv7;
         if: "!startsWith(github.ref, 'refs/tags/v')"
 
       - name: goreleaser release
@@ -117,9 +126,17 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: remove slash from image tag
+        uses: mad9000/actions-find-and-replace-string@3
+        id: replaceslash
+        with:
+          source: ${{ github.head_ref || github.ref_name }}
+          find: '/'
+          replace: '-'
+        if: "!startsWith(github.ref, 'refs/tags/v')"
       - name: Run tests
         env:
-          IMAGE: ghcr.io/ecadlabs/signatory:${{ github.head_ref || github.ref_name }}-amd64
+          IMAGE: ghcr.io/ecadlabs/signatory:${{ steps.replaceslash.outputs.value }}-amd64
           VAULT_AWS_USER: ${{ secrets.INTEGRATIONTEST_VAULT_AWS_USER }}
           VAULT_AWS_KEY: ${{ secrets.INTEGRATIONTEST_VAULT_AWS_KEY }}
           VAULT_AWS_SECRET: ${{ secrets.INTEGRATIONTEST_VAULT_AWS_SECRET }}


### PR DESCRIPTION
it is common convention to name branches with prefixes that include a slash
`fix/issue-xyz` or `feature\abc`
we use branch name to tag pre-release docker images.  when the branch has a slash, an invalid docker image tag is formed and the tag of the image fails. 

from the build log we see this branch named `fix/tagswithslash` yielded the following image tags `Run docker push ghcr.io/ecadlabs/signatory:fix-tagswithslash-amd64; docker push ghcr.io/ecadlabs/signatory:fix-tagswithslash-arm64; docker push ghcr.io/ecadlabs/signatory:fix-tagswithslash-armv7;`