### PR TITLE
use pull_request_target trigger

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,8 +4,7 @@ on:
       - "main"
     tags:
       - "v*"
-      - "rc*"
-  pull_request:
+  pull_request_target:
 
 name: Test and publish
 


### PR DESCRIPTION
workflow trigger pull_request_target will allow a PR from a fork access to this repo's secrets and GITHUB_TOKEN
currently PRs opened from fork workflows fail on pushing snapshot build to ghcr

the rc tag was removed, it's not needed