### PR TITLE
Move the watermark logic to the DB side

### DIFF
--- a/pkg/signatory/watermark/aws.go
+++ b/pkg/signatory/watermark/aws.go
@@ -134,61 +134,33 @@ func (a *AWS) IsSafeToSign(ctx context.Context, pkh crypt.PublicKeyHash, req pro
 		return nil
 	}
 	wm := request.NewWatermark(m, digest)
-	prev := watermark{
+
+	wmData := watermark{
 		Idx:     strings.Join([]string{m.GetChainID().String(), pkh.String()}, "/"),
 		Request: req.SignRequestKind(),
+		Level:   wm.Level,
+		Round:   wm.Round,
+		Digest:  wm.Hash.UnwrapPtr(),
 	}
-	for {
-		response, err := a.client.GetItem(ctx, &dynamodb.GetItemInput{
-			Key:       prev.key(),
-			TableName: aws.String(a.cfg.table()),
-		})
-		if err != nil {
-			return fmt.Errorf("(AWSWatermark) IsSafeToSign: %w", err)
-		}
-
-		update := watermark{
-			Idx:     prev.Idx,
-			Request: prev.Request,
-			Level:   wm.Level,
-			Round:   wm.Round,
-			Digest:  wm.Hash.UnwrapPtr(),
-		}
-		item, err := attributevalue.MarshalMap(&update)
-		if err != nil {
-			return fmt.Errorf("(AWSWatermark) IsSafeToSign: %w", err)
-		}
-		input := dynamodb.PutItemInput{
-			TableName: aws.String(a.cfg.table()),
-			Item:      item,
-		}
-
-		if response.Item != nil {
-			if err := attributevalue.UnmarshalMap(response.Item, &prev); err != nil {
-				return fmt.Errorf("(AWSWatermark) IsSafeToSign: %w", err)
-			}
-			if !wm.Validate(prev.watermark()) {
-				return ErrWatermark
-			}
-			input.ConditionExpression = aws.String("lvl = :lvl AND round = :round AND digest = :digest")
-			input.ExpressionAttributeValues = map[string]types.AttributeValue{
-				":lvl":    response.Item["lvl"],
-				":round":  response.Item["round"],
-				":digest": response.Item["digest"],
-			}
-		} else {
-			input.ConditionExpression = aws.String("attribute_not_exists(idx)")
-		}
-
-		_, err = a.client.PutItem((ctx), &input)
-		var serr smithy.APIError
-		if err == nil {
-			return nil
-		} else if !errors.As(err, &serr) || serr.ErrorCode() != "ConditionalCheckFailedException" {
-			return fmt.Errorf("(AWSWatermark) IsSafeToSign: %w", err)
-		}
-		// retry
+	item, err := attributevalue.MarshalMap(&wmData)
+	if err != nil {
+		return fmt.Errorf("(AWSWatermark) IsSafeToSign: %w", err)
 	}
+	putItemInput := dynamodb.PutItemInput{
+		TableName:           aws.String(a.cfg.table()),
+		Item:                item,
+		ConditionExpression: aws.String("attribute_not_exists(idx) or lvl < :new_lvl or (lvl = :new_lvl and round < :new_round)"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":new_lvl":   item["lvl"],
+			":new_round": item["round"],
+		},
+	}
+	_, err = a.client.PutItem((ctx), &putItemInput)
+	if err != nil {
+		log.Error(err)
+		return ErrWatermark
+	}
+	return nil
 }
 
 func init() {


### PR DESCRIPTION
While in theory the existing implementation shouldn't return a positive result until it successfully updated the record using a conditional expression, there is a flaw somewhere else. Anyway if we use the conditional update to do the actual watermark logic instead of just checking for a concurrent update everything begin to look very clean and straightforward. So a decision was made to adopt this pattern