### PR TITLE
docs(ledger): Nano S EOL notice, NVRAM wear info, link fixes, and watermark notes

### DIFF
--- a/docs/ledger.md
+++ b/docs/ledger.md
@@ -5,24 +5,23 @@ title: Ledger
 
 # Ledger vault
 
-Connect the ledger device to the system in which signatory is running.
-Install tezos-wallet and tezos-baker apps from [ledger live](https://www.ledger.com/ledger-live/download).
+Connect the Ledger device to the system where Signatory is running.
+Install the Tezos Wallet and Tezos Baking apps from [Ledger Live](https://www.ledger.com/ledger-live/download).
 
-Note: Developer mode might be needed to install baker app.
-[Ledger Developer mode](https://developers.ledger.com/docs/live-app/developer-mode/#:~:text=To%20activate%20the%20Developer%20mode,Live%20version%202.32%20and%20above.)
+Note: Developer mode might be required to install the Baking app. See [Ledger Developer mode](https://developers.ledger.com/docs/live-app/developer-mode/#:~:text=To%20activate%20the%20Developer%20mode,Live%20version%202.32%20and%20above.).
 
 :::caution Ledger Nano S end-of-support
 Ledger has discontinued support for the Ledger Nano S. If you are using a Nano S with Signatory for baking or signing, you should upgrade to a supported device:
 
 - Ledger Nano S+ or Ledger Nano X (see product pages for current availability)
-- A server‑grade HSM such as YubiHSM 2 (see `docs/yubihsm.md`)
+- A server-grade HSM such as YubiHSM 2 (see `docs/yubihsm.md`)
 
 References: [Ledger Nano S limitations/support](https://support.ledger.com/article/Ledger-Nano-S-Limitations), [Ledger hardware wallets](https://shop.ledger.com/pages/hardware-wallet), [Ledger Nano S Plus](https://shop.ledger.com/products/ledger-nano-s-plus).
 :::
 
 :::info Flash/NVRAM duty cycle and proactive replacement for bakers
-- The ST secure elements used in Ledger devices specify about 500,000 erase/write cycles per flash page (64‑byte pages) and ~30‑year data retention. See [BOLOS memory](https://github.com/LedgerHQ/ledger-dev-doc/blob/master/source/userspace/memory.rst), [ST31G480](https://www.st.com/en/secure-mcus/st31g480.html), and [ST31G256 datasheet](https://www.st.com/resource/en/data_brief/st31g256.pdf).
-- Older versions of the Tezos Baking app persisted the High Watermark (HWM) to NVRAM after each signed operation, which could accelerate wear. In March–April 2024 the app added a setting to disable HWM persistence and moved HWM tracking to RAM, significantly reducing writes; writes to NVRAM now occur only in limited cases (e.g., clean exit). See the app documentation/readme: [LedgerHQ/app-tezos-baking](https://github.com/LedgerHQ/app-tezos-baking).
+- The ST secure elements used in Ledger devices specify about 500,000 erase/write cycles per flash page (64-byte pages) and ~30-year data retention. See [BOLOS memory](https://github.com/LedgerHQ/ledger-dev-doc/blob/master/source/userspace/memory.rst), [ST31G480](https://www.st.com/en/secure-mcus/st31g480.html), and [ST31G256 datasheet](https://www.st.com/resource/en/data_brief/st31g256.pdf).
+- Older versions of the Tezos Baking app persisted the High Watermark (HWM) to NVRAM after each signed operation, which could accelerate wear. In March–April 2024, the app added a setting to disable HWM persistence and moved HWM tracking to RAM, significantly reducing writes; writes to NVRAM now occur only in limited cases (e.g., clean exit). See the app documentation/README: [LedgerHQ/app-tezos-baking](https://github.com/LedgerHQ/app-tezos-baking).
 - Recommendation: Bakers using older Ledger devices (especially those used for baking prior to the 2024 improvements) should proactively upgrade hardware. If you continue to use a Ledger for baking, install the latest Tezos Baking app and consider disabling HWM persistence to minimize flash wear.
 :::
 
@@ -30,21 +29,21 @@ References: [Ledger Nano S limitations/support](https://support.ledger.com/artic
 
 | Name        | Type         | Required | Description                                                   |
 |-------------|--------------|----------|---------------------------------------------------------------|
-| id          | string       |     ✅    | Ledger Device ID. Use first available device if not specified |
-| keys        | string array |     ✅    | Managed key IDs                                               |
-| close_after | duration     |    OPTIONAL      | Close device after a certain period of inactivity             |
+| id          | string       | Yes      | Ledger device ID. Uses the first available device if not specified |
+| keys        | string array | Yes      | Managed key IDs                                               |
+| close_after | duration     | No       | Close the device after a certain period of inactivity         |
 
-### Keys & ID format and meaning
+### Keys and ID format
 
 Syntax: `derivation/bip32`
 
-Where `bip32` is [BIP 0032](https://en.bitcoin.it/wiki/BIP_0032) path and
-`derivation` is one of derivation schemes: `ed25519`, `secp256k1`, `p-256`,
+Where `bip32` is a [BIP 0032](https://en.bitcoin.it/wiki/BIP_0032) path and
+`derivation` is one of the following schemes: `ed25519`, `secp256k1`, `p-256`,
 `secp256r1` (alias for `p-256`), `bip25519`, `bip32-ed25519` (alias for
 `bip25519`). `bip25519` is a [BIP 0032](https://en.bitcoin.it/wiki/BIP_0032)
-compliant scheme, others use some sort of a custom hash chain.
+compliant scheme; the others use a custom hash chain.
 
-Ledger specific root `m/44'/1729'` may be omitted.
+Ledger-specific root `m/44'/1729'` may be omitted.
 
 Examples (equivalent): `bip32-ed25519/m/44'/1729'/0'/0'`,
 `bip32-ed25519/44'/1729'/0'/0'`, `bip25519/0'/0'`
@@ -63,20 +62,20 @@ vaults:
       close_after: 3600s
 ```
 
-### **close_after field in config**
+### close_after field in config
 
-Configure this value as per your requirement. As you don't know the time between the blocks assigned to your baker, it is better to configure it for at least a few hours to prevent the ledger from closing, often due to inactivity.
+Configure this value as required. Because you do not know the time between the blocks assigned to your baker, configure it for at least a few hours to prevent the Ledger device from closing due to inactivity.
 
 Example:
 
-```sh
+```yaml
 close_after: 3600s
 ```
 
 ### Transports
 
-By default Ledger vault uses `usb` transport. Another available transport is `tcp` used primarily for interaction with [Speculos](https://github.com/LedgerHQ/speculos)
-emulator. It can be enabled using `transport` option:
+By default, the Ledger vault uses the `usb` transport. Another available transport is `tcp`, used primarily for interaction with the [Speculos](https://github.com/LedgerHQ/speculos)
+emulator. It can be enabled using the `transport` option:
 
 ```yaml
 vaults:
@@ -91,16 +90,16 @@ vaults:
       close_after: 3600s
 ```
 
-In addition `signatory-cli ledger` command also accepts `-t` / `--transport` key with the same URL-like syntax:
+In addition, the `signatory-cli ledger` command also accepts the `-t`/`--transport` option with the same URL-like syntax:
 
 ```sh
 signatory-cli ledger --transport 'tcp://127.0.0.1:9999' list
 ```
 
-## Getting data from ledger for signatory configuration using CLI
+## Getting data from Ledger for Signatory configuration using the CLI
 
-Keep tezos-wallet app open for the below commands and for signing any wallet transactions.
-During every wallet transaction `Accept/Reject` input should be provided in the ledger when prompted.
+Keep the Tezos Wallet app open for the commands below and for signing any wallet transactions.
+During every wallet transaction, provide Accept/Reject input on the Ledger device when prompted.
 
 ```sh
     % ./signatory-cli list -c ./sig-ledger.yaml 
@@ -127,12 +126,12 @@ Version: TezBake 2.2.11 a6fbd27f
 
 ### Ledger device lock
 
-Signatory acquires a read lock on the ledger device when in operation. Be aware that when the Signatory service is running, and it has a valid configuration for a ledger device, the signatory-cli binary will encounter error "ledger: hidapi: failed to open device" trying to list ledgers. Only 1 process can acquire a read lock on the ledger device.
+Signatory acquires a read lock on the Ledger device while in operation. When the Signatory service is running and has a valid configuration for a Ledger device, the `signatory-cli` binary will encounter the error "ledger: hidapi: failed to open device" when trying to list ledgers. Only one process can acquire a read lock on the Ledger device.
 
-## Setup baking with signatory and ledger
+## Set up baking with Signatory and Ledger
 
-Keep tezos-baker app open for the below configurations and when the baker is running.
-No prompt will be seen in ledger during signing operations.
+Keep the Tezos Baking app open for the configurations below and when the baker is running.
+No user interaction is required on the Ledger device during signing operations.
 
 ```sh
 signatory-cli ledger setup-baking [--chain-id <chain_id>] [--main-hwm <hwm>] [--test-hwm <hwm>] [-d <device>] <path>
@@ -144,7 +143,7 @@ Example:
 signatory-cli ledger setup-baking -d 3944f7a0 "bip32-ed25519/44'/1729'/0'/0'"
 ```
 
-### Reset high water marks
+### Reset High Watermarks
 
 ```sh
 signatory-cli ledger set-high-watermark [-d <device>] <hwm>

--- a/docs/ledger.md
+++ b/docs/ledger.md
@@ -11,6 +11,21 @@ Install tezos-wallet and tezos-baker apps from [ledger live](https://www.ledger.
 Note: Developer mode might be needed to install baker app.
 [Ledger Developer mode](https://developers.ledger.com/docs/live-app/developer-mode/#:~:text=To%20activate%20the%20Developer%20mode,Live%20version%202.32%20and%20above.)
 
+:::caution Ledger Nano S end-of-support
+Ledger has discontinued support for the Ledger Nano S. If you are using a Nano S with Signatory for baking or signing, you should upgrade to a supported device:
+
+- Ledger Nano S+ or Ledger Nano X (see product pages for current availability)
+- A server‑grade HSM such as YubiHSM 2 (see `docs/yubihsm.md`)
+
+References: [Ledger Nano S limitations/support](https://support.ledger.com/article/Ledger-Nano-S-Limitations), [Ledger hardware wallets](https://shop.ledger.com/pages/hardware-wallet), [Ledger Nano S Plus](https://shop.ledger.com/products/ledger-nano-s-plus).
+:::
+
+:::info Flash/NVRAM duty cycle and proactive replacement for bakers
+- The ST secure elements used in Ledger devices specify about 500,000 erase/write cycles per flash page (64‑byte pages) and ~30‑year data retention. See [BOLOS memory](https://github.com/LedgerHQ/ledger-dev-doc/blob/master/source/userspace/memory.rst), [ST31G480](https://www.st.com/en/secure-mcus/st31g480.html), and [ST31G256 datasheet](https://www.st.com/resource/en/data_brief/st31g256.pdf).
+- Older versions of the Tezos Baking app persisted the High Watermark (HWM) to NVRAM after each signed operation, which could accelerate wear. In March–April 2024 the app added a setting to disable HWM persistence and moved HWM tracking to RAM, significantly reducing writes; writes to NVRAM now occur only in limited cases (e.g., clean exit). See the app documentation/readme: [LedgerHQ/app-tezos-baking](https://github.com/LedgerHQ/app-tezos-baking).
+- Recommendation: Bakers using older Ledger devices (especially those used for baking prior to the 2024 improvements) should proactively upgrade hardware. If you continue to use a Ledger for baking, install the latest Tezos Baking app and consider disabling HWM persistence to minimize flash wear.
+:::
+
 ## Configuration
 
 | Name        | Type         | Required | Description                                                   |

--- a/docs/ledger.md
+++ b/docs/ledger.md
@@ -5,6 +5,8 @@ title: Ledger
 
 # Ledger vault
 
+Ledger devices are well suited for home baking and hobbyists. They are consumer‑oriented devices that provide secure key storage at low cost and make Tezos baking accessible. For larger or production bakers, consider server‑grade HSMs such as YubiHSM 2 or cloud KMS solutions (for example, AWS KMS or Google Cloud KMS). See [YubiHSM 2](./yubihsm.md), [AWS KMS](./aws_kms.md), and [GCP KMS](./gcp_kms.md) for details.
+
 Connect the Ledger device to the system where Signatory is running.
 Install the Tezos Wallet and Tezos Baking apps from [Ledger Live](https://www.ledger.com/ledger-live/download).
 
@@ -14,7 +16,7 @@ Note: Developer mode might be required to install the Baking app. See [Ledger De
 Ledger has discontinued support for the Ledger Nano S. If you are using a Nano S with Signatory for baking or signing, you should upgrade to a supported device:
 
 - Ledger Nano S+ or Ledger Nano X (see product pages for current availability)
-- A server-grade HSM such as YubiHSM 2 (see `docs/yubihsm.md`)
+- A server-grade HSM such as [YubiHSM 2](./yubihsm.md)
 
 References: [Ledger Nano S limitations/support](https://support.ledger.com/article/Ledger-Nano-S-Limitations), [Ledger hardware wallets](https://shop.ledger.com/pages/hardware-wallet), [Ledger Nano S Plus](https://shop.ledger.com/products/ledger-nano-s-plus).
 :::
@@ -144,6 +146,10 @@ signatory-cli ledger setup-baking -d 3944f7a0 "bip32-ed25519/44'/1729'/0'/0'"
 ```
 
 ### Reset High Watermarks
+
+Signatory maintains per-key high watermarks to prevent replay and double signing. For details on behavior, reset, and migration, see [Watermarks](./watermarks.md).
+
+Note: The Ledger Tezos Baking app also tracks a high watermark internally on the device. When using Ledger with Signatory, both watermarks exist: the device-level HWM and Signatory’s server-side watermark. Ensure they are aligned, especially after reinstalling the Ledger app or migrating setups. You can initialize or update the device HWM with the commands below; Signatory’s watermark is maintained by the service according to its [watermark policy](./watermarks.md).
 
 ```sh
 signatory-cli ledger set-high-watermark [-d <device>] <hwm>


### PR DESCRIPTION
- Add caution about Ledger Nano S end-of-support and upgrade guidance (Nano S+/Nano X or YubiHSM 2 / cloud KMS)
- Add intro on Ledger suitability for home/hobby baking; recommend server-grade HSM/KMS for larger bakers
- Convert backticked doc references to Docusaurus links (YubiHSM, AWS KMS, GCP KMS)
- Expand watermarks section: link to Signatory Watermarks doc and note device-level HWM alongside Signatory’s watermark tracking
- Copy edits for capitalization, punctuation, and headings