### PR TITLE
Website: mobile layout + footer tidy + gradient everywhere + fix edit links

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -140,7 +140,8 @@ module.exports = {
 				docs: {
 					path: '../docs',
 					sidebarPath: require.resolve('./sidebars.js'),
-					editUrl: 'https://github.com/ecadlabs/signatory/edit/master/website/',
+					// Use the 'main' branch for "Edit this page" links
+					editUrl: 'https://github.com/ecadlabs/signatory/edit/main/docs/',
 				},
 				theme: {
 					customCss: [

--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -239,6 +239,16 @@ __docusaurus {
 	padding-bottom: 20px;
 }
 
+/* Remove bullets/padding from footer lists */
+.footer__items {
+	list-style: none;
+	margin: 0;
+	padding-left: 0;
+}
+.footer__item {
+	list-style: none;
+}
+
 .footer__links .footer__col {
 	flex: unset;
 	padding-left: 0px !important;
@@ -408,7 +418,7 @@ __docusaurus {
 		white-space: unset;
 	}
 
-	.row .col.col.col {
+	.footer .row .col {
 		--ifm-col-width: 50%;
 		flex-basis: unset;
 		margin-left: 0;
@@ -466,7 +476,7 @@ __docusaurus {
 		white-space: unset;
 	}
 
-	.row .col.col.col {
+	.footer .row .col {
 		--ifm-col-width: 50%;
 		flex-basis: unset;
 		margin-left: 0;

--- a/website/src/theme/Footer/index.js
+++ b/website/src/theme/Footer/index.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import { useThemeConfig } from '@docusaurus/theme-common';
@@ -67,7 +67,6 @@ const FooterLogo = ({ sources, alt, width, height }) => (
 
 function Footer() {
 	const footerContainer = useRef(null);
-	const [isActive, setIsActive] = useState(false);
 	const { footer } = useThemeConfig();
 	const { copyright, links = [], logo = {} } = footer || {};
 	const sources = {
@@ -98,21 +97,10 @@ function Footer() {
 	//   };
 	// }, []);
 
-	const [bg, setBg] = useState(
-		'linear-gradient(132.76deg, #a13455 -80.79%, #1a1e44 54.08%)'
-	);
-
-	useEffect(() => {
-		if (typeof window !== 'undefined' && window.location.pathname !== '/') {
-			setBg('#1A1E44');
-		}
-	}, []);
+	// Use CSS-defined gradient background for footer on all pages.
 
 	return (
 		<footer
-			style={{
-				background: `${bg}`,
-			}}
 			className={clsx('footer', {
 				'footer--dark': footer.style === 'dark',
 			})}


### PR DESCRIPTION
- Fix docs content width on mobile by scoping 50% column rule to footer only
- Remove bullets and extra padding from footer lists
- Use gradient footer background on all pages (remove inline flat color override)
- Fix "Edit this page" links to point to main branch

Screenshots: see issue conversation.

No functional changes to app code.