### PR TITLE
docs: update configuration examples with modern terminology and DAL support

### DIFF
--- a/docs/aws_dynamodb.md
+++ b/docs/aws_dynamodb.md
@@ -57,7 +57,7 @@ This is the recommended approach for production deployments.
 When Signatory initializes the AWS backend, it automatically creates the DynamoDB table if it doesn't already exist. The table is created with:
 
 - Partition key: `idx` (combination of chain ID and public key hash)
-- Sort key: `request` (type of request: block, endorsement, etc.)
+- Sort key: `request` (type of request: block, attestation, etc.)
 - Provisioned capacity: 5 read and 5 write capacity units
 
 When Signatory starts up, it will log one of these messages to confirm which table is being used:

--- a/docs/aws_kms.md
+++ b/docs/aws_kms.md
@@ -66,17 +66,17 @@ vaults:
       region: {AWS_Region}
 # This section is for public key hashes to define what is activated IRL
 tezos:
-  # Default policy allows "block" and "endorsement" operations
+  # Default policy allows "block" and "attestation" operations
   {public_key_hash}:
     log_payloads: true
     allowed_operations:
-      # List of [generic, block, endorsement]
+      # List of [generic, block, attestation]
       - generic
       - block
-      - endorsement
+      - attestation
     allowed_kinds:
       - transaction
-      - endorsement
+      - attestation
       - reveal
       - delegation
     authorized_keys:
@@ -104,8 +104,8 @@ Public Key Hash:    tz3WxgnteyTpM5YzJSTFFtnNYB8Du31gf3bQ
 Vault:              AWSKMS
 ID:                 arn:aws:kms:us-east-2:461830523399:key/038ec90c-1809-4320-9dc8-9cb05a8ef5bb
 Active:             true
-Allowed Operations: [block endorsement generic]
-Allowed Kinds:      [delegation endorsement reveal transaction]
+Allowed Operations: [block attestation generic]
+Allowed Kinds:      [delegation attestation reveal transaction]
 ```
 
 ### Final Signatory Verification Test

--- a/docs/aws_kms.md
+++ b/docs/aws_kms.md
@@ -70,10 +70,11 @@ tezos:
   {public_key_hash}:
     log_payloads: true
     allowed_operations:
-      # List of [generic, block, attestation]
+      # List of [generic, block, attestation, preattestation]
       - generic
       - block
       - attestation
+      - preattestation
     allowed_kinds:
       - transaction
       - attestation

--- a/docs/azure_kms.md
+++ b/docs/azure_kms.md
@@ -314,8 +314,9 @@ tezos:
     log_payloads: true
     allow:
       block:
-      endorsement:
-      preendorsement:
+      attestation:        # Modern terminology (was "endorsement")
+      preattestation:     # Modern terminology (was "preendorsement")
+      attestation_with_dal: # Required for DAL participation
       generic:
         - transaction
         - reveal

--- a/docs/bakers.md
+++ b/docs/bakers.md
@@ -220,9 +220,18 @@ See the official [Signatory documentation](https://signatory.io/docs/) for AWS/G
 
 ## Baking with DAL (Data Availability Layer)
 
-**Critical Signatory Configuration for DAL**
+The Data Availability Layer (DAL) enables data publication outside of Layer 1 blocks while maintaining decentralization. DAL participation **earns additional incentives** from the network protocol and **supports the Tezos X roadmap** by providing high-bandwidth data distribution for smart rollups.
 
-If your baker participates in DAL attestations, you **must** add `attestation_with_dal` to your Signatory policy. This is a separate operation type from regular attestations.
+### Why Run a DAL Node?
+
+- **Additional Rewards**: Earn extra incentives for DAL attestations (10% of participation rewards)
+- **Network Support**: Help scale Tezos by supporting smart rollup data distribution
+- **Tezos X Roadmap**: Contribute to the future of Tezos scaling infrastructure
+- **Competitive Advantage**: Stay ahead as DAL becomes increasingly important
+
+### Critical Signatory Configuration
+
+If your baker participates in DAL attestations, you **must** add `attestation_with_dal` to your Signatory policy:
 
 ```yaml
 tezos:
@@ -232,7 +241,7 @@ tezos:
       block:              # Standard block baking
       attestation:        # Standard attestations
       preattestation:     # Pre-attestations  
-      attestation_with_dal: # ✨ Required for DAL attestations
+      attestation_with_dal: # Required for DAL attestations
       generic:
         - transaction
         - reveal
@@ -240,32 +249,40 @@ tezos:
         - stake
 ```
 
-:::note Terminology
-Signatory supports both old (`endorsement`/`preendorsement`) and modern (`attestation`/`preattestation`) terminology in policy configuration. Both work identically, but we recommend using the modern terms to match current Tezos protocol terminology.
-:::
-
-**DAL Setup Overview**
-
-To participate in DAL attestations:
-
-1. **Run a DAL node** alongside your Tezos node
-2. **Configure your baker** to use the DAL node (`--dal-node` flag)
-3. **Update Signatory policy** to allow `attestation_with_dal` operations
-
 :::warning Important
 Without `attestation_with_dal` in your Signatory policy, DAL attestation requests will be rejected, and you'll miss those rewards.
 :::
 
-**Consensus Keys and DAL**
+### Key Requirements
 
-While consensus keys are not strictly required for DAL operations, **using consensus keys is considered current best practice** for production baking setups. Consensus keys provide operational flexibility and security benefits by separating the baker's identity (manager key) from the key used for consensus operations (baking, attesting).
+**BLS Consensus Keys (tz4)**: A **companion key is mandatory** for DAL attestations. Without it, tz4 bakers cannot produce DAL attestations.
 
-**Further Reading**
+```bash
+# Register companion key for existing delegate
+octez-client set companion key for <manager_key> to <companion_key>
+```
 
-The details of running DAL nodes and collecting DAL attestation rewards are outside the scope of this Signatory guide. For comprehensive information:
+**DAL Operations**:
+- **`attestation_with_dal`**: Required for DAL participation
+  - Standard keys (tz1, tz2, tz3): Single consensus key signature
+  - BLS keys (tz4): Requires both consensus key AND companion key signatures
+- **`dal_entrapment_evidence`**: **DO NOT ALLOW** - Anonymous operation, no signature needed
+- **`dal_publish_commitment`**: **DO NOT ALLOW** - Only needed if publishing data to DAL
 
-- **[Tezos DAL Architecture](https://docs.tezos.com/architecture/data-availability-layer)** - explains what the DAL is, how bakers run with a DAL attester node, and how DAL rewards work (10% of participation rewards starting in Rio; you must attest ≥64% of assigned shards; "trap shard" denouncements can forfeit the cycle's DAL rewards)
-- **[DAL Node Setup Guide](https://octez.tezos.com/docs/shell/dal_run.html)** - step-by-step setup guide for the DAL attester node
+### Setup Overview
+
+1. **Run a DAL node** alongside your Tezos node (see [DAL Node Setup Guide](https://octez.tezos.com/docs/shell/dal_run.html))
+2. **Configure your baker** to use the DAL node (`--dal-node` flag)
+3. **Update Signatory policy** to allow `attestation_with_dal` operations
+
+```bash
+# Start baker with DAL integration
+octez-baker run with local node ~/.tezos-node \
+  --liquidity-baking-toggle-vote pass \
+  --dal-node http://127.0.0.1:10732
+```
+
+**Further Reading**: [Tezos DAL Architecture](https://docs.tezos.com/architecture/data-availability-layer) | [DAL Node Setup Guide](https://octez.tezos.com/docs/shell/dal_run.html)
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -79,8 +79,8 @@ Public Key Hash:    tz3gxd1y7FdVJ81vzvuACcVjAc4ewXARQkLo
 Vault:              Azure
 ID:                 https://forimport.vault.azure.net/keys/signatory-imported-2Csev40hxBXjwo5wVVnRbonNaDl/ce48c88caf744549b638e97bf89acb1b
 Active:             true
-Allowed Operations: [block endorsement generic preendorsement]
-Allowed Kinds:      [endorsement transaction]
+Allowed Operations: [block attestation generic preattestation]
+Allowed Kinds:      [attestation transaction]
 ```
 
 **Note:** `--base-dir` can be provided in the config.yaml file itself. Below is a sample layout of a config file.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -98,8 +98,9 @@ tezos:
     log_payloads: true
     allow:
       block:
-      endorsement:
-      preendorsement:
+      attestation:        # Modern terminology (was "endorsement")
+      preattestation:     # Modern terminology (was "preendorsement")
+      attestation_with_dal: # Required for DAL participation
       generic:
         - transaction
   tz3***:

--- a/docs/gcp_firestore.md
+++ b/docs/gcp_firestore.md
@@ -74,7 +74,7 @@ This hierarchical structure ensures that:
 ### Data Structure
 
 Each watermark document contains:
-- `request`: The type of request (block, endorsement, etc.)
+- `request`: The type of request (block, attestation, etc.)
 - `lvl`: The block level
 - `round`: The round number
 - `digest`: The operation digest hash

--- a/docs/gcp_kms.md
+++ b/docs/gcp_kms.md
@@ -112,8 +112,9 @@ tezos:
     log_payloads: true
     allow:
       block:
-      endorsement:
-      preendorsement:
+      attestation:        # Modern terminology (was "endorsement")
+      preattestation:     # Modern terminology (was "preendorsement")
+      attestation_with_dal: # Required for DAL participation
       generic:
         - transaction
 ```

--- a/docs/jwt_auth.md
+++ b/docs/jwt_auth.md
@@ -149,8 +149,9 @@ tezos:
     log_payloads: true
     allow:
       block:
-      endorsement:
-      preendorsement:
+      attestation:        # Modern terminology (was "endorsement")
+      preattestation:     # Modern terminology (was "preendorsement")
+      attestation_with_dal: # Required for DAL participation
       generic:
         - transaction
         - reveal

--- a/docs/ledger.md
+++ b/docs/ledger.md
@@ -110,8 +110,8 @@ During every wallet transaction, provide Accept/Reject input on the Ledger devic
     Vault:              Ledger
     ID:                 bip32-ed25519/44'/1729'/0'/0'
     Active:             true
-    Allowed Operations: [block endorsement generic]
-    Allowed Kinds:      [delegation endorsement origination reveal transaction]
+    Allowed Operations: [block attestation generic]
+    Allowed Kinds:      [delegation attestation origination reveal transaction]
     Public Key Hash:    tz2ByDXtXn3Wj4k6DoJnyKHMA68xJvL1nBmV
     Vault:              Ledger
     ID:                 secp256k1/44'/1729'/0'/1'

--- a/docs/localsecret.md
+++ b/docs/localsecret.md
@@ -28,8 +28,9 @@ tezos:
     log_payloads: true
     allow:
       block:
-      endorsement:
-      preendorsement:
+      attestation:        # Modern terminology (was "endorsement")
+      preattestation:     # Modern terminology (was "preendorsement")
+      attestation_with_dal: # Required for DAL participation
       generic:
         - transaction
 ```

--- a/docs/start.md
+++ b/docs/start.md
@@ -13,7 +13,7 @@ sidebar_label: Getting Started
 
 ## What is Signatory
 
-Signatory is a remote signing daemon that allows Tezos bakers to sign endorsement and baking operations with various key-management systems.
+Signatory is a remote signing daemon that allows Tezos bakers to sign attestation and baking operations with various key-management systems.
 
 Signatory currently supports [AWS KMS][aws], [Azure Key Vault][azure], [GCP Key Management][gcp], [YubiHSM][yubi], [Hashicorp Vault][hashicorp], and Confidential Computing TEEs such as [AWS Nitro Enclaves](nitro.md) and [Google Confidential Space](confidential_space.md). For development/prototyping purposes, Signatory can also sign with a [local private key](localsecret.md).
 
@@ -25,8 +25,6 @@ By supporting multiple Cloud KMS/HSM systems, we hope to help the network from c
 
 Observability is a first-class concern. Signatory allows for rich reporting and alerting capabilities. It exposes metrics about its operation via Prometheus metrics, enabling teams to set up robust monitoring of their critical infrastructure and allowing operators to see historical trends, signing volumes, errors and latencies. Users can report feature requests, security issues, or bug reports can via the Github project page: 
 github.com/ecadlabs/signatory or via email to security@ecadlabs.com
-
-Security issues can be encrypted using the keys available at https://keybase.io/jevonearth
 
 ## How Signatory Works
 
@@ -52,6 +50,10 @@ Signatory configuration is specified in a YAML file. Use the `signatory.yaml` fi
 You can configure multiple `vault`s. Each `vault` should be configured to use a backend. Same backend can be used in more than one `vault`.
 
 The configuration file is shared between `signatory` and `signatory-cli`.
+
+:::note Baker Operations
+For bakers, ensure your configuration includes `attestation` and `preattestation` operations. If you're running a DAL node, also add `attestation_with_dal` to participate in DAL attestations and earn additional rewards. See the [Bakers guide](bakers.md) for detailed configuration examples.
+:::
 
 ### Configuration Example - File-based Vault
 
@@ -80,7 +82,7 @@ watermark:
 
 # List enabled public keys hashes here
 tezos:
-  # Default policy allows "block" and "endorsement" operations
+  # Default policy allows "block" and "attestation" operations
   tz1Wz4ZabKRsz842Xuzy4a7CcWADfPVsPKus:
 
   # Explicit policy
@@ -91,8 +93,9 @@ tezos:
     log_payloads: true
     allow:
       block:
-      endorsement:
-      preendorsement:
+      attestation:        # Modern terminology (was "endorsement")
+      preattestation:     # Modern terminology (was "preendorsement")
+      attestation_with_dal: # Required for DAL participation
       failing_noop:
       generic:
         - transaction
@@ -140,8 +143,9 @@ tezos:
   tz3MhmeqpudUqEX8PYTbNDF3CVcnnjNQoo8N:
     allow:
       block:
-      endorsement:
-      preendorsement:
+      attestation:        # Modern terminology (was "endorsement")
+      preattestation:     # Modern terminology (was "preendorsement")
+      attestation_with_dal: # Required for DAL participation
       failing_noop:
       generic:
         - delegation
@@ -225,7 +229,7 @@ This endpoint is useful for monitoring, or declarative tests as part of deployme
 
 ### Testing
 
-To test the signing operation, you can send a post to Signatory. In this example, we are sending a dummy operation of type `02`, which is an `endorsement` operation type.
+To test the signing operation, you can send a post to Signatory. In this example, we are sending a dummy operation of type `02`, which is an `attestation` operation type.
 
 ```sh
 curl -XPOST \
@@ -296,7 +300,7 @@ INFO[0000] Initializing vault                            vault=azure vault_name=
 Public Key Hash:    tz3VfoCwiQyMNYnaseFLFAjN9AQJQnhvddjG
 Vault:              CloudKMS
 ID:                 projects/signatory-testing/locations/europe-north1/keyRings/hsm-ring/cryptoKeys/hsm-key/cryptoKeyVersions/1
-Allowed Operations: [block endorsement]
+Allowed Operations: [block attestation]
 Allowed Kinds:      []
 
 Public Key Hash:    tz3ZqyLdKy2doLbw7yghLPz2TWWZdxeLGKVx
@@ -307,8 +311,8 @@ ID:                 projects/signatory-testing/locations/europe-north1/keyRings/
 Public Key Hash:    tz3aTwpna6m9qsw4YZVFad1nsm5cGgWHVQ8R
 Vault:              CloudKMS
 ID:                 projects/signatory-testing/locations/europe-north1/keyRings/hsm-ring/cryptoKeys/signatory-imported-1RG8mJUH8P5ncMEMypfkno98Gpq/cryptoKeyVersions/1
-Allowed Operations: [block endorsement generic]
-Allowed Kinds:      [endorsement transaction]
+Allowed Operations: [block attestation generic]
+Allowed Kinds:      [attestation transaction]
 
 Public Key Hash:    tz3VkMSRVjLwEoUgZNJwjoD6YHeBDXyWiBaY
 Vault:              Azure

--- a/docs/watermarks.md
+++ b/docs/watermarks.md
@@ -25,7 +25,7 @@ Watermarks provide three critical benefits:
 
 Here's the basic flow of how watermarks operate:
 
-1. When Signatory receives a signing request (block, endorsement, etc.), it extracts the operation's level and round number
+1. When Signatory receives a signing request (block, attestation, etc.), it extracts the operation's level and round number
 2. Signatory checks the stored watermark for the corresponding key and operation type
 3. If the new operation has a higher level or round, it's allowed to proceed
 4. After successful signing, the watermark is updated to the new level/round

--- a/docs/yubihsm.md
+++ b/docs/yubihsm.md
@@ -178,6 +178,10 @@ tezos:
   tz1SBhzLDp9Jvg98ztMZMstaKbAENmzRd4Y7:
     log_payloads: true
     allow:
+      block:
+      attestation:        # Modern terminology (was "endorsement")
+      preattestation:     # Modern terminology (was "preendorsement")
+      attestation_with_dal: # Required for DAL participation
       generic:
         - origination
 ```


### PR DESCRIPTION


**Key Changes**:
- Updated all configuration examples to use modern Tezos terminology (`attestation` instead of `endorsement`)
- Added `attestation_with_dal` to all baker configuration examples
- Enhanced the DAL section in `bakers.md` with more guidance

**Benefits**:
- New users see correct configuration from the start
- Bakers understand DAL requirements immediately
- Consistent terminology across all documentation
- Complete examples for current Tezos protocols

