### PR TITLE
docs: fix documentation errors and inconsistencies

### DIFF
--- a/docs/proof_of_possession.md
+++ b/docs/proof_of_possession.md
@@ -139,20 +139,20 @@ When registering a tz4 companion key for DAL:
 
 ```yaml
 tezos:
-  # Main baker key
+  # Main baker key (tz1/tz2/tz3)
   tz1BakerAddress:
     allow:
       block:
       attestation:
-      attestation_with_dal:
+      attestation_with_dal:  # tz1/tz2/tz3 keys use this for DAL
       generic:
-        - register_dal_companion
-  
+        - set_companion_key
+
   # DAL companion key (tz4)
   tz4CompanionKeyHash:
     allow_proof_of_possession: true  # Enable for registration
     allow:
-      attestation_with_dal:
+      attestation:  # tz4 keys use 'attestation' only, NOT 'attestation_with_dal'
 ```
 
 After successful registration, disable POP:
@@ -161,7 +161,7 @@ After successful registration, disable POP:
   tz4CompanionKeyHash:
     allow_proof_of_possession: false
     allow:
-      attestation_with_dal:
+      attestation:  # tz4 keys use 'attestation' only, NOT 'attestation_with_dal'
 ```
 
 ### Pattern 4: Multisig Setup

--- a/docs/remote_policy.md
+++ b/docs/remote_policy.md
@@ -80,7 +80,7 @@ policy_hook:
 }
 ```
 
-The signature is calculated from the `payload` JSON object **as it present in the request**.
+The signature is calculated from the `payload` JSON object **as it is present in the request**.
 
 ### Non authenticated reply
 

--- a/docs/start.md
+++ b/docs/start.md
@@ -125,7 +125,7 @@ tezos:
 ```
 
 ### Configuration Example - AWS KMS Vault
-This configuration example uses AWS KMS as  
+This configuration example uses AWS KMS as the vault backend for secure key management.
 
 ```yaml
 server:
@@ -228,7 +228,7 @@ Signatory exposes Prometheus metrics and health status on the address specified 
 
 Metrics include counters and histograms that track signing operations and errors.
 
-The metrics are intended to be scraped using the Prometheus time series database. We also publish a ready-made Grafana dashboard that users can use to visualize the operation of their signing operations. (TODO: publish Grafana dashboard)
+The metrics are intended to be scraped using the Prometheus time series database.
 
 `localhost:9583/metrics`
 

--- a/docs/yubihsm.md
+++ b/docs/yubihsm.md
@@ -21,7 +21,7 @@ This documentation assumes that you will be running Signatory and the YubiHSM2 d
 
 * A Linux system operably configured with:
   * Docker
-  * The [yubihsm2 sdk][yubisdk] version 2012.12 or later installed. This documentation assumes you are using Docker on Debian.
+  * The [yubihsm2 sdk][yubisdk] version 2021.12 or later installed. This documentation assumes you are using Docker on Debian.
 * A YubiHSM device connected to your server. (See the output of `lsusb` to verify)
 
 ### Installing and using the YubiHSM Connector and Shell
@@ -34,7 +34,7 @@ The connector requires you to have the libusb package installed on your system.
 apt-get install libusb-1.0-0
 ```
 
-To install the connector, find and install the 
+To install the connector, download the package from the Yubico releases page and install it:
 
 ```bash
 dpkg -i yubihsm-connector_2.1.0-1_amd64.deb


### PR DESCRIPTION
## Summary
- Fix incomplete sentence in start.md for AWS KMS configuration example
- Remove TODO placeholder for Grafana dashboard in start.md  
- Fix POP companion key example in proof_of_possession.md to use correct 'attestation' permission for tz4 keys instead of 'attestation_with_dal'
- Fix grammatical error in remote_policy.md ("as it present" → "as it is present")
- Fix YubiHSM SDK version typo (2012.12 → 2021.12) in yubihsm.md
- Fix incomplete sentence about connector installation in yubihsm.md

## Details

### start.md
- Line 128: Completed sentence "This configuration example uses AWS KMS as" → "This configuration example uses AWS KMS as the vault backend for secure key management."
- Line 231: Removed unpublished TODO for Grafana dashboard

### proof_of_possession.md  
- Pattern 3 (DAL Companion Key): Fixed tz4 companion key example that incorrectly showed `attestation_with_dal` permission. BLS keys (tz4) use `attestation` only per the DAL/BLS documentation.
- Also updated generic operation from `register_dal_companion` to `set_companion_key`

### remote_policy.md
- Fixed grammar: "as it present in the request" → "as it is present in the request"

### yubihsm.md
- Fixed SDK version typo: 2012.12 → 2021.12
- Completed sentence: "To install the connector, find and install the" → "To install the connector, download the package from the Yubico releases page and install it:"

## Test plan
- [ ] Review changes for accuracy
- [ ] Verify documentation renders correctly on signatory.io after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Documentation fixes and clarifications**
> 
> - Corrects DAL companion key example in `proof_of_possession.md`: tz1/tz2/tz3 use `attestation_with_dal`; tz4 uses `attestation` only; updates generic op to `set_companion_key`
> - Completes AWS KMS example sentence and removes Grafana dashboard TODO in `start.md`; minor wording cleanup in metrics section
> - Fixes grammar in `remote_policy.md` (signature text: "as it is present")
> - Updates `yubihsm.md` to `yubihsm2 sdk` version `2021.12` and clarifies connector installation instructions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d428eb149a0a3204fb32e5a015d1d355d733772f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->