### PR TITLE
chore(website): update dependencies

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,29 +8,29 @@
 			"name": "signatory",
 			"version": "0.0.0",
 			"dependencies": {
-				"@docusaurus/core": "^3.8.1",
-				"@docusaurus/preset-classic": "^3.8.1",
-				"@docusaurus/theme-mermaid": "^3.8.1",
-				"@mdx-js/react": "^3.1.0",
+				"@docusaurus/core": "^3.9.2",
+				"@docusaurus/preset-classic": "^3.9.2",
+				"@docusaurus/theme-mermaid": "^3.9.2",
+				"@mdx-js/react": "^3.1.1",
 				"classnames": "^2.5.1",
 				"clsx": "^2.1.1",
 				"docusaurus-plugin-sass": "^0.2.6",
-				"html-react-parser": "^5.2.6",
+				"html-react-parser": "^5.2.11",
 				"prism-react-renderer": "^2.4.1",
-				"react": "^19.1.1",
-				"react-dom": "^19.1.1",
+				"react": "^19.2.3",
+				"react-dom": "^19.2.3",
 				"react-use-mailchimp-signup": "^2.0.2"
 			}
 		},
 		"node_modules/@ai-sdk/gateway": {
-			"version": "2.0.24",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.24.tgz",
-			"integrity": "sha512-mflk80YF8hj8vrF9e1IHhovGKC1ubX+sY88pesSk3pUiXfH5VPO8dgzNnxjwsqsCZrnkHcztxS5cSl4TzSiEuA==",
+			"version": "2.0.27",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.27.tgz",
+			"integrity": "sha512-8hbezMsGa0crSt7/DKjkYL1UbbJJW/UFxTfhmf5qcIeYeeWG4dTNmm+DWbUdIsTaWvp59KC4eeC9gYXBbTHd7w==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@ai-sdk/provider": "2.0.1",
 				"@ai-sdk/provider-utils": "3.0.20",
-				"@vercel/oidc": "3.0.5"
+				"@vercel/oidc": "3.1.0"
 			},
 			"engines": {
 				"node": ">=18"
@@ -69,13 +69,13 @@
 			}
 		},
 		"node_modules/@ai-sdk/react": {
-			"version": "2.0.119",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-2.0.119.tgz",
-			"integrity": "sha512-kl4CDAnKJ1z+Fc9cjwMQXLRqH5/gHhg8Jn9qW7sZ0LgL8VpiDmW+x+s8e588nE3eC88aL1OxOVyOE6lFYfWprw==",
+			"version": "2.0.123",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-2.0.123.tgz",
+			"integrity": "sha512-exaEvHAsDdR0wgzF3l0BmC9U1nPLnkPK2CCnX3BP4RDj/PySZvPXjry3AOz1Ayb8KSPZgWklVRzxsQxrOYQJxA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@ai-sdk/provider-utils": "3.0.20",
-				"ai": "5.0.117",
+				"ai": "5.0.121",
 				"swr": "^2.2.5",
 				"throttleit": "2.1.0"
 			},
@@ -93,15 +93,15 @@
 			}
 		},
 		"node_modules/@algolia/abtesting": {
-			"version": "1.12.2",
-			"resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.12.2.tgz",
-			"integrity": "sha512-oWknd6wpfNrmRcH0vzed3UPX0i17o4kYLM5OMITyMVM2xLgaRbIafoxL0e8mcrNNb0iORCJA0evnNDKRYth5WQ==",
+			"version": "1.12.3",
+			"resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.12.3.tgz",
+			"integrity": "sha512-0SpSdnME0RCS6UHSs9XD3ox4bMcCg1JTmjAJ3AU6rcTlX54CZOAEPc2as8uSghX6wfKGT0HWes4TeUpjJMg6FQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.2",
-				"@algolia/requester-browser-xhr": "5.46.2",
-				"@algolia/requester-fetch": "5.46.2",
-				"@algolia/requester-node-http": "5.46.2"
+				"@algolia/client-common": "5.46.3",
+				"@algolia/requester-browser-xhr": "5.46.3",
+				"@algolia/requester-fetch": "5.46.3",
+				"@algolia/requester-node-http": "5.46.3"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
@@ -140,100 +140,100 @@
 			}
 		},
 		"node_modules/@algolia/client-abtesting": {
-			"version": "5.46.2",
-			"resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.46.2.tgz",
-			"integrity": "sha512-oRSUHbylGIuxrlzdPA8FPJuwrLLRavOhAmFGgdAvMcX47XsyM+IOGa9tc7/K5SPvBqn4nhppOCEz7BrzOPWc4A==",
+			"version": "5.46.3",
+			"resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.46.3.tgz",
+			"integrity": "sha512-i2C8sBcl3EKXuCd5nlGohW+pZ9pY3P3JKJ2OYqsbCPg6wURiR32hNDiDvDq7/dqJ7KWWwC2snxJhokZzGlckgQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.2",
-				"@algolia/requester-browser-xhr": "5.46.2",
-				"@algolia/requester-fetch": "5.46.2",
-				"@algolia/requester-node-http": "5.46.2"
+				"@algolia/client-common": "5.46.3",
+				"@algolia/requester-browser-xhr": "5.46.3",
+				"@algolia/requester-fetch": "5.46.3",
+				"@algolia/requester-node-http": "5.46.3"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-analytics": {
-			"version": "5.46.2",
-			"resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.46.2.tgz",
-			"integrity": "sha512-EPBN2Oruw0maWOF4OgGPfioTvd+gmiNwx0HmD9IgmlS+l75DatcBkKOPNJN+0z3wBQWUO5oq602ATxIfmTQ8bA==",
+			"version": "5.46.3",
+			"resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.46.3.tgz",
+			"integrity": "sha512-uFmD7m3LOym1SAURHeiqupHT9jui+9HK0lAiIvm077gXEscOM5KKXM4rg/ICzQ3UDHLZEA0Lb5TglWsXnieE6w==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.2",
-				"@algolia/requester-browser-xhr": "5.46.2",
-				"@algolia/requester-fetch": "5.46.2",
-				"@algolia/requester-node-http": "5.46.2"
+				"@algolia/client-common": "5.46.3",
+				"@algolia/requester-browser-xhr": "5.46.3",
+				"@algolia/requester-fetch": "5.46.3",
+				"@algolia/requester-node-http": "5.46.3"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-common": {
-			"version": "5.46.2",
-			"resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.46.2.tgz",
-			"integrity": "sha512-Hj8gswSJNKZ0oyd0wWissqyasm+wTz1oIsv5ZmLarzOZAp3vFEda8bpDQ8PUhO+DfkbiLyVnAxsPe4cGzWtqkg==",
+			"version": "5.46.3",
+			"resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.46.3.tgz",
+			"integrity": "sha512-SN+yK840nXa+2+mF72hrDfGd8+B7eBjF8TK/8KoRMdjlAkO/P3o3vtpjKRKI/Sk4L8kYYkB/avW8l+cwR+O1Ew==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-insights": {
-			"version": "5.46.2",
-			"resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.46.2.tgz",
-			"integrity": "sha512-6dBZko2jt8FmQcHCbmNLB0kCV079Mx/DJcySTL3wirgDBUH7xhY1pOuUTLMiGkqM5D8moVZTvTdRKZUJRkrwBA==",
+			"version": "5.46.3",
+			"resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.46.3.tgz",
+			"integrity": "sha512-5ic1liG0VucNPi6gKCWh5bEUGWQfyEmVeXiNKS+rOSppg7B7nKH0PEEJOFXBbHmgK5aPfNNZINiKcyUoH4XsFA==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.2",
-				"@algolia/requester-browser-xhr": "5.46.2",
-				"@algolia/requester-fetch": "5.46.2",
-				"@algolia/requester-node-http": "5.46.2"
+				"@algolia/client-common": "5.46.3",
+				"@algolia/requester-browser-xhr": "5.46.3",
+				"@algolia/requester-fetch": "5.46.3",
+				"@algolia/requester-node-http": "5.46.3"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-personalization": {
-			"version": "5.46.2",
-			"resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.46.2.tgz",
-			"integrity": "sha512-1waE2Uqh/PHNeDXGn/PM/WrmYOBiUGSVxAWqiJIj73jqPqvfzZgzdakHscIVaDl6Cp+j5dwjsZ5LCgaUr6DtmA==",
+			"version": "5.46.3",
+			"resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.46.3.tgz",
+			"integrity": "sha512-f4HNitgTip8tntKgluYBTc1LWSOkbNCdxZvRA3rRBZnEAYSvLe7jpE+AxRep6RY+prSWwMtyeCFhA/F1Um+TuQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.2",
-				"@algolia/requester-browser-xhr": "5.46.2",
-				"@algolia/requester-fetch": "5.46.2",
-				"@algolia/requester-node-http": "5.46.2"
+				"@algolia/client-common": "5.46.3",
+				"@algolia/requester-browser-xhr": "5.46.3",
+				"@algolia/requester-fetch": "5.46.3",
+				"@algolia/requester-node-http": "5.46.3"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-query-suggestions": {
-			"version": "5.46.2",
-			"resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.46.2.tgz",
-			"integrity": "sha512-EgOzTZkyDcNL6DV0V/24+oBJ+hKo0wNgyrOX/mePBM9bc9huHxIY2352sXmoZ648JXXY2x//V1kropF/Spx83w==",
+			"version": "5.46.3",
+			"resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.46.3.tgz",
+			"integrity": "sha512-/AaVqah2aYyJj7Cazu5QRkgcV3HF3lkBJo5TRkgqQ26xR4iHNRbLF2YsWJfJpJEFghlTF2HOCh7IgzaUCnM+8A==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.2",
-				"@algolia/requester-browser-xhr": "5.46.2",
-				"@algolia/requester-fetch": "5.46.2",
-				"@algolia/requester-node-http": "5.46.2"
+				"@algolia/client-common": "5.46.3",
+				"@algolia/requester-browser-xhr": "5.46.3",
+				"@algolia/requester-fetch": "5.46.3",
+				"@algolia/requester-node-http": "5.46.3"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-search": {
-			"version": "5.46.2",
-			"resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.46.2.tgz",
-			"integrity": "sha512-ZsOJqu4HOG5BlvIFnMU0YKjQ9ZI6r3C31dg2jk5kMWPSdhJpYL9xa5hEe7aieE+707dXeMI4ej3diy6mXdZpgA==",
+			"version": "5.46.3",
+			"resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.46.3.tgz",
+			"integrity": "sha512-hfpCIukPuwkrlwsYfJEWdU5R5bduBHEq2uuPcqmgPgNq5MSjmiNIzRuzxGZZgiBKcre6gZT00DR7G1AFn//wiQ==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@algolia/client-common": "5.46.2",
-				"@algolia/requester-browser-xhr": "5.46.2",
-				"@algolia/requester-fetch": "5.46.2",
-				"@algolia/requester-node-http": "5.46.2"
+				"@algolia/client-common": "5.46.3",
+				"@algolia/requester-browser-xhr": "5.46.3",
+				"@algolia/requester-fetch": "5.46.3",
+				"@algolia/requester-node-http": "5.46.3"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
@@ -246,81 +246,81 @@
 			"license": "MIT"
 		},
 		"node_modules/@algolia/ingestion": {
-			"version": "1.46.2",
-			"resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.46.2.tgz",
-			"integrity": "sha512-1Uw2OslTWiOFDtt83y0bGiErJYy5MizadV0nHnOoHFWMoDqWW0kQoMFI65pXqRSkVvit5zjXSLik2xMiyQJDWQ==",
+			"version": "1.46.3",
+			"resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.46.3.tgz",
+			"integrity": "sha512-ChVzNkCzAVxKozTnTgPWCG69WQLjzW7X6OqD91zUh8U38ZhPEX/t3qGhXs+M9ZNaHcJ7xToMB3jywNwONhpLGA==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.2",
-				"@algolia/requester-browser-xhr": "5.46.2",
-				"@algolia/requester-fetch": "5.46.2",
-				"@algolia/requester-node-http": "5.46.2"
+				"@algolia/client-common": "5.46.3",
+				"@algolia/requester-browser-xhr": "5.46.3",
+				"@algolia/requester-fetch": "5.46.3",
+				"@algolia/requester-node-http": "5.46.3"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/monitoring": {
-			"version": "1.46.2",
-			"resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.46.2.tgz",
-			"integrity": "sha512-xk9f+DPtNcddWN6E7n1hyNNsATBCHIqAvVGG2EAGHJc4AFYL18uM/kMTiOKXE/LKDPyy1JhIerrh9oYb7RBrgw==",
+			"version": "1.46.3",
+			"resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.46.3.tgz",
+			"integrity": "sha512-MZa+Z5iPmVMxVAQ0aq4HpGsja5utSLEMcOuY01X8D46vvMrSPkP8DnlDFtu1PgJ0RwyIGqqx7v+ClFo6iRJ6bA==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.2",
-				"@algolia/requester-browser-xhr": "5.46.2",
-				"@algolia/requester-fetch": "5.46.2",
-				"@algolia/requester-node-http": "5.46.2"
+				"@algolia/client-common": "5.46.3",
+				"@algolia/requester-browser-xhr": "5.46.3",
+				"@algolia/requester-fetch": "5.46.3",
+				"@algolia/requester-node-http": "5.46.3"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/recommend": {
-			"version": "5.46.2",
-			"resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.46.2.tgz",
-			"integrity": "sha512-NApbTPj9LxGzNw4dYnZmj2BoXiAc8NmbbH6qBNzQgXklGklt/xldTvu+FACN6ltFsTzoNU6j2mWNlHQTKGC5+Q==",
+			"version": "5.46.3",
+			"resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.46.3.tgz",
+			"integrity": "sha512-cr3atJRJBKgAKZl/Oxo4sig6Se0+ukbyIOOluPV5H+ZAXVcxuMoXQgwQ1M5UHPnCnEsZ4uBXhBmilRgUQpUegw==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.2",
-				"@algolia/requester-browser-xhr": "5.46.2",
-				"@algolia/requester-fetch": "5.46.2",
-				"@algolia/requester-node-http": "5.46.2"
+				"@algolia/client-common": "5.46.3",
+				"@algolia/requester-browser-xhr": "5.46.3",
+				"@algolia/requester-fetch": "5.46.3",
+				"@algolia/requester-node-http": "5.46.3"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/requester-browser-xhr": {
-			"version": "5.46.2",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.46.2.tgz",
-			"integrity": "sha512-ekotpCwpSp033DIIrsTpYlGUCF6momkgupRV/FA3m62SreTSZUKjgK6VTNyG7TtYfq9YFm/pnh65bATP/ZWJEg==",
+			"version": "5.46.3",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.46.3.tgz",
+			"integrity": "sha512-/Ku9GImJf2SKoRM2S3e03MjCVaWJCP5olih4k54DRhNDdmxBkd3nsWuUXvDElY3Ucw/arBYGs5SYz79SoS5APw==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.2"
+				"@algolia/client-common": "5.46.3"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/requester-fetch": {
-			"version": "5.46.2",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.46.2.tgz",
-			"integrity": "sha512-gKE+ZFi/6y7saTr34wS0SqYFDcjHW4Wminv8PDZEi0/mE99+hSrbKgJWxo2ztb5eqGirQTgIh1AMVacGGWM1iw==",
+			"version": "5.46.3",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.46.3.tgz",
+			"integrity": "sha512-Uw+SPy/zpfwbH1AxQaeOWvWVzPEcO0XbtLbbSz0HPcEIiBGWyfa9LUCxD5UferbDjrSQNVimmzl3FaWi4u8Ykw==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.2"
+				"@algolia/client-common": "5.46.3"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/requester-node-http": {
-			"version": "5.46.2",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.46.2.tgz",
-			"integrity": "sha512-ciPihkletp7ttweJ8Zt+GukSVLp2ANJHU+9ttiSxsJZThXc4Y2yJ8HGVWesW5jN1zrsZsezN71KrMx/iZsOYpg==",
+			"version": "5.46.3",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.46.3.tgz",
+			"integrity": "sha512-4No9iTjr1GZ0JWsFbQJj9aZBnmKyY1sTxOoEud9+SGe3U6iAulF0A0lI4cWi/F/Gcfg8V3jkaddcqSQKDnE45w==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.2"
+				"@algolia/client-common": "5.46.3"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
@@ -340,12 +340,12 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.28.6.tgz",
+			"integrity": "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.28.5",
 				"js-tokens": "^4.0.0",
 				"picocolors": "^1.1.1"
 			},
@@ -354,30 +354,30 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
-			"integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.6.tgz",
+			"integrity": "sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-			"integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
+			"integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.28.5",
-				"@babel/helper-compilation-targets": "^7.27.2",
-				"@babel/helper-module-transforms": "^7.28.3",
-				"@babel/helpers": "^7.28.4",
-				"@babel/parser": "^7.28.5",
-				"@babel/template": "^7.27.2",
-				"@babel/traverse": "^7.28.5",
-				"@babel/types": "^7.28.5",
+				"@babel/code-frame": "^7.28.6",
+				"@babel/generator": "^7.28.6",
+				"@babel/helper-compilation-targets": "^7.28.6",
+				"@babel/helper-module-transforms": "^7.28.6",
+				"@babel/helpers": "^7.28.6",
+				"@babel/parser": "^7.28.6",
+				"@babel/template": "^7.28.6",
+				"@babel/traverse": "^7.28.6",
+				"@babel/types": "^7.28.6",
 				"@jridgewell/remapping": "^2.3.5",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
@@ -403,13 +403,13 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-			"integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.6.tgz",
+			"integrity": "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.28.5",
-				"@babel/types": "^7.28.5",
+				"@babel/parser": "^7.28.6",
+				"@babel/types": "^7.28.6",
 				"@jridgewell/gen-mapping": "^0.3.12",
 				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
@@ -431,12 +431,12 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.27.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-			"integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+			"integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.27.2",
+				"@babel/compat-data": "^7.28.6",
 				"@babel/helper-validator-option": "^7.27.1",
 				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
@@ -456,17 +456,17 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.5.tgz",
-			"integrity": "sha512-q3WC4JfdODypvxArsJQROfupPBq9+lMwjKq7C33GhbFYJsufD0yd/ziwD+hJucLeWsnFPWZjsU2DNFqBPE7jwQ==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
+			"integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.27.3",
 				"@babel/helper-member-expression-to-functions": "^7.28.5",
 				"@babel/helper-optimise-call-expression": "^7.27.1",
-				"@babel/helper-replace-supers": "^7.27.1",
+				"@babel/helper-replace-supers": "^7.28.6",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-				"@babel/traverse": "^7.28.5",
+				"@babel/traverse": "^7.28.6",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -550,27 +550,27 @@
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-			"integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+			"integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/traverse": "^7.27.1",
-				"@babel/types": "^7.27.1"
+				"@babel/traverse": "^7.28.6",
+				"@babel/types": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.28.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-			"integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+			"integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.27.1",
-				"@babel/traverse": "^7.28.3"
+				"@babel/helper-module-imports": "^7.28.6",
+				"@babel/helper-validator-identifier": "^7.28.5",
+				"@babel/traverse": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -592,9 +592,9 @@
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-			"integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+			"integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -618,14 +618,14 @@
 			}
 		},
 		"node_modules/@babel/helper-replace-supers": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
-			"integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
+			"integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-member-expression-to-functions": "^7.27.1",
+				"@babel/helper-member-expression-to-functions": "^7.28.5",
 				"@babel/helper-optimise-call-expression": "^7.27.1",
-				"@babel/traverse": "^7.27.1"
+				"@babel/traverse": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -675,39 +675,39 @@
 			}
 		},
 		"node_modules/@babel/helper-wrap-function": {
-			"version": "7.28.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.3.tgz",
-			"integrity": "sha512-zdf983tNfLZFletc0RRXYrHrucBEg95NIFMkn6K9dbeMYnsgHaSBGcQqdsCSStG2PYwRre0Qc2NNSCXbG+xc6g==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.6.tgz",
+			"integrity": "sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.27.2",
-				"@babel/traverse": "^7.28.3",
-				"@babel/types": "^7.28.2"
+				"@babel/template": "^7.28.6",
+				"@babel/traverse": "^7.28.6",
+				"@babel/types": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.28.4",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-			"integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+			"integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.28.4"
+				"@babel/template": "^7.28.6",
+				"@babel/types": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-			"integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
+			"integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.28.5"
+				"@babel/types": "^7.28.6"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -780,13 +780,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-			"version": "7.28.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.3.tgz",
-			"integrity": "sha512-b6YTX108evsvE4YgWyQ921ZAFFQm3Bn+CA3+ZXlNVnPhx+UfsVURoPjfGAPCjBgrqo30yX/C2nZGX96DxvR9Iw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.6.tgz",
+			"integrity": "sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1",
-				"@babel/traverse": "^7.28.3"
+				"@babel/helper-plugin-utils": "^7.28.6",
+				"@babel/traverse": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -820,12 +820,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-import-assertions": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.27.1.tgz",
-			"integrity": "sha512-UT/Jrhw57xg4ILHLFnzFpPDlMbcdEicaAtjPQpbj9wa8T4r5KVWCimHcL/460g8Ht0DMxDyjsLgiWSkVjnwPFg==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.28.6.tgz",
+			"integrity": "sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -835,12 +835,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-import-attributes": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
-			"integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+			"integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -850,12 +850,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-jsx": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
-			"integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+			"integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -865,12 +865,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-typescript": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
-			"integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+			"integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -911,14 +911,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-generator-functions": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.0.tgz",
-			"integrity": "sha512-BEOdvX4+M765icNPZeidyADIvQ1m1gmunXufXxvRESy/jNNyfovIqUyE7MVgGBjWktCoJlzvFA1To2O4ymIO3Q==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.6.tgz",
+			"integrity": "sha512-9knsChgsMzBV5Yh3kkhrZNxH3oCYAfMBkNNaVN4cP2RVlFPe8wYdwwcnOsAbkdDoV9UjFtOXWrWB52M8W4jNeA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.28.6",
 				"@babel/helper-remap-async-to-generator": "^7.27.1",
-				"@babel/traverse": "^7.28.0"
+				"@babel/traverse": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -928,13 +928,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-to-generator": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.27.1.tgz",
-			"integrity": "sha512-NREkZsZVJS4xmTr8qzE5y8AfIPqsdQfRuUiLRTEzb7Qii8iFWCyDKaUV2c0rCuh4ljDZ98ALHP/PetiBV2nddA==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.28.6.tgz",
+			"integrity": "sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-module-imports": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6",
 				"@babel/helper-remap-async-to-generator": "^7.27.1"
 			},
 			"engines": {
@@ -960,12 +960,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-block-scoping": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.5.tgz",
-			"integrity": "sha512-45DmULpySVvmq9Pj3X9B+62Xe+DJGov27QravQJU1LLcapR6/10i+gYVAucGGJpHBp5mYxIMK4nDAT/QDLr47g==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.6.tgz",
+			"integrity": "sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -975,13 +975,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-class-properties": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.27.1.tgz",
-			"integrity": "sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.28.6.tgz",
+			"integrity": "sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-create-class-features-plugin": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -991,13 +991,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-class-static-block": {
-			"version": "7.28.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.3.tgz",
-			"integrity": "sha512-LtPXlBbRoc4Njl/oh1CeD/3jC+atytbnf/UqLoqTDcEYGUPj022+rvfkbDYieUrSj3CaV4yHDByPE+T2HwfsJg==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.6.tgz",
+			"integrity": "sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.28.3",
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-create-class-features-plugin": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1007,17 +1007,17 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-classes": {
-			"version": "7.28.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.4.tgz",
-			"integrity": "sha512-cFOlhIYPBv/iBoc+KS3M6et2XPtbT2HiCRfBXWtfpc9OAyostldxIf9YAYB6ypURBBbx+Qv6nyrLzASfJe+hBA==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.6.tgz",
+			"integrity": "sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.27.3",
-				"@babel/helper-compilation-targets": "^7.27.2",
+				"@babel/helper-compilation-targets": "^7.28.6",
 				"@babel/helper-globals": "^7.28.0",
-				"@babel/helper-plugin-utils": "^7.27.1",
-				"@babel/helper-replace-supers": "^7.27.1",
-				"@babel/traverse": "^7.28.4"
+				"@babel/helper-plugin-utils": "^7.28.6",
+				"@babel/helper-replace-supers": "^7.28.6",
+				"@babel/traverse": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1027,13 +1027,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-computed-properties": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.27.1.tgz",
-			"integrity": "sha512-lj9PGWvMTVksbWiDT2tW68zGS/cyo4AkZ/QTp0sQT0mjPopCmrSkzxeXkznjqBxzDI6TclZhOJbBmbBLjuOZUw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.28.6.tgz",
+			"integrity": "sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1",
-				"@babel/template": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6",
+				"@babel/template": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1059,13 +1059,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-dotall-regex": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.27.1.tgz",
-			"integrity": "sha512-gEbkDVGRvjj7+T1ivxrfgygpT7GUd4vmODtYpbs0gZATdkX8/iSnOtZSxiZnsgm1YjTgjI6VKBGSJJevkrclzw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.28.6.tgz",
+			"integrity": "sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-create-regexp-features-plugin": "^7.28.5",
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1090,13 +1090,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.27.1.tgz",
-			"integrity": "sha512-hkGcueTEzuhB30B3eJCbCYeCaaEQOmQR0AdvzpD4LoN0GXMWzzGSuRrxR2xTnCrvNbVwK9N6/jQ92GSLfiZWoQ==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.28.6.tgz",
+			"integrity": "sha512-5suVoXjC14lUN6ZL9OLKIHCNVWCrqGqlmEp/ixdXjvgnEl/kauLvvMO/Xw9NyMc95Joj1AeLVPVMvibBgSoFlA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-create-regexp-features-plugin": "^7.28.5",
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1121,13 +1121,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-explicit-resource-management": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.0.tgz",
-			"integrity": "sha512-K8nhUcn3f6iB+P3gwCv/no7OdzOZQcKchW6N389V6PD8NUWKZHzndOd9sPDVbMoBsbmjMqlB4L9fm+fEFNVlwQ==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.6.tgz",
+			"integrity": "sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1",
-				"@babel/plugin-transform-destructuring": "^7.28.0"
+				"@babel/helper-plugin-utils": "^7.28.6",
+				"@babel/plugin-transform-destructuring": "^7.28.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1137,12 +1137,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-exponentiation-operator": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.28.5.tgz",
-			"integrity": "sha512-D4WIMaFtwa2NizOp+dnoFjRez/ClKiC2BqqImwKd1X28nqBtZEyCYJ2ozQrrzlxAFrcrjxo39S6khe9RNDlGzw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.28.6.tgz",
+			"integrity": "sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1200,12 +1200,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-json-strings": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.27.1.tgz",
-			"integrity": "sha512-6WVLVJiTjqcQauBhn1LkICsR2H+zm62I3h9faTDKt1qP4jn2o72tSvqMwtGFKGTpojce0gJs+76eZ2uCHRZh0Q==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.28.6.tgz",
+			"integrity": "sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1230,12 +1230,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-logical-assignment-operators": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.5.tgz",
-			"integrity": "sha512-axUuqnUTBuXyHGcJEVVh9pORaN6wC5bYfE7FGzPiaWa3syib9m7g+/IT/4VgCOe2Upef43PHzeAvcrVek6QuuA==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.6.tgz",
+			"integrity": "sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1276,13 +1276,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-commonjs": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz",
-			"integrity": "sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
+			"integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-module-transforms": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1357,12 +1357,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz",
-			"integrity": "sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.28.6.tgz",
+			"integrity": "sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1372,12 +1372,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-numeric-separator": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.27.1.tgz",
-			"integrity": "sha512-fdPKAcujuvEChxDBJ5c+0BTaS6revLV7CJL08e4m3de8qJfNIuCc2nc7XJYOjBoTMJeqSmwXJ0ypE14RCjLwaw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.28.6.tgz",
+			"integrity": "sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1387,16 +1387,16 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-object-rest-spread": {
-			"version": "7.28.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.4.tgz",
-			"integrity": "sha512-373KA2HQzKhQCYiRVIRr+3MjpCObqzDlyrM6u4I201wL8Mp2wHf7uB8GhDwis03k2ti8Zr65Zyyqs1xOxUF/Ew==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.6.tgz",
+			"integrity": "sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.27.2",
-				"@babel/helper-plugin-utils": "^7.27.1",
-				"@babel/plugin-transform-destructuring": "^7.28.0",
+				"@babel/helper-compilation-targets": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6",
+				"@babel/plugin-transform-destructuring": "^7.28.5",
 				"@babel/plugin-transform-parameters": "^7.27.7",
-				"@babel/traverse": "^7.28.4"
+				"@babel/traverse": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1422,12 +1422,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-optional-catch-binding": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.27.1.tgz",
-			"integrity": "sha512-txEAEKzYrHEX4xSZN4kJ+OfKXFVSWKB2ZxM9dpcE3wT7smwkNmXo5ORRlVzMVdJbD+Q8ILTgSD7959uj+3Dm3Q==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.28.6.tgz",
+			"integrity": "sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1437,12 +1437,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-optional-chaining": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.5.tgz",
-			"integrity": "sha512-N6fut9IZlPnjPwgiQkXNhb+cT8wQKFlJNqcZkWlcTqkcqx6/kU4ynGmLFoa4LViBSirn05YAwk+sQBbPfxtYzQ==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.6.tgz",
+			"integrity": "sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.28.6",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
 			},
 			"engines": {
@@ -1468,13 +1468,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-private-methods": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.27.1.tgz",
-			"integrity": "sha512-10FVt+X55AjRAYI9BrdISN9/AQWHqldOeZDUoLyif1Kn05a56xVBXb8ZouL8pZ9jem8QpXaOt8TS7RHUIS+GPA==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.28.6.tgz",
+			"integrity": "sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-create-class-features-plugin": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1484,14 +1484,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-private-property-in-object": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.27.1.tgz",
-			"integrity": "sha512-5J+IhqTi1XPa0DXF83jYOaARrX+41gOewWbkPyjMNRDqgOCqdffGh8L3f/Ek5utaEBZExjSAzcyjmV9SSAWObQ==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.28.6.tgz",
+			"integrity": "sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.27.1",
-				"@babel/helper-create-class-features-plugin": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-annotate-as-pure": "^7.27.3",
+				"@babel/helper-create-class-features-plugin": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1546,16 +1546,16 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-react-jsx": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.27.1.tgz",
-			"integrity": "sha512-2KH4LWGSrJIkVf5tSiBFYuXDAoWRq2MMwgivCf+93dd0GQi8RXLjKA/0EvRnVV5G0hrHczsquXuD01L8s6dmBw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.28.6.tgz",
+			"integrity": "sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.27.1",
-				"@babel/helper-module-imports": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1",
-				"@babel/plugin-syntax-jsx": "^7.27.1",
-				"@babel/types": "^7.27.1"
+				"@babel/helper-annotate-as-pure": "^7.27.3",
+				"@babel/helper-module-imports": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6",
+				"@babel/plugin-syntax-jsx": "^7.28.6",
+				"@babel/types": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1596,12 +1596,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-regenerator": {
-			"version": "7.28.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.4.tgz",
-			"integrity": "sha512-+ZEdQlBoRg9m2NnzvEeLgtvBMO4tkFBw5SQIUgLICgTrumLoU7lr+Oghi6km2PFj+dbUt2u1oby2w3BDO9YQnA==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.6.tgz",
+			"integrity": "sha512-eZhoEZHYQLL5uc1gS5e9/oTknS0sSSAtd5TkKMUp3J+S/CaUjagc0kOUPsEbDmMeva0nC3WWl4SxVY6+OBuxfw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1611,13 +1611,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-regexp-modifiers": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.27.1.tgz",
-			"integrity": "sha512-TtEciroaiODtXvLZv4rmfMhkCv8jx3wgKpL68PuiPh2M4fvz5jhsA7697N1gMvkvr/JTF13DrFYyEbY9U7cVPA==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.28.6.tgz",
+			"integrity": "sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-create-regexp-features-plugin": "^7.28.5",
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1686,12 +1686,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-spread": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.27.1.tgz",
-			"integrity": "sha512-kpb3HUqaILBJcRFVhFUs6Trdd4mkrzcGXss+6/mxUd273PfbWqSDHRzMT2234gIg2QYfAjvXLSquP1xECSg09Q==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.28.6.tgz",
+			"integrity": "sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.28.6",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
 			},
 			"engines": {
@@ -1747,16 +1747,16 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-typescript": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.5.tgz",
-			"integrity": "sha512-x2Qa+v/CuEoX7Dr31iAfr0IhInrVOWZU/2vJMJ00FOR/2nM0BcBEclpaf9sWCDc+v5e9dMrhSH8/atq/kX7+bA==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.6.tgz",
+			"integrity": "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.27.3",
-				"@babel/helper-create-class-features-plugin": "^7.28.5",
-				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-create-class-features-plugin": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-				"@babel/plugin-syntax-typescript": "^7.27.1"
+				"@babel/plugin-syntax-typescript": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1781,13 +1781,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-property-regex": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.27.1.tgz",
-			"integrity": "sha512-uW20S39PnaTImxp39O5qFlHLS9LJEmANjMG7SxIhap8rCHqu0Ik+tLEPX5DKmHn6CsWQ7j3lix2tFOa5YtL12Q==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.28.6.tgz",
+			"integrity": "sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-create-regexp-features-plugin": "^7.28.5",
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1813,13 +1813,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-sets-regex": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.27.1.tgz",
-			"integrity": "sha512-EtkOujbc4cgvb0mlpQefi4NTPBzhSIevblFevACNLUspmrALgmEBdL/XfnyyITfd8fKBZrZys92zOWcik7j9Tw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.28.6.tgz",
+			"integrity": "sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-create-regexp-features-plugin": "^7.28.5",
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1829,75 +1829,75 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.5.tgz",
-			"integrity": "sha512-S36mOoi1Sb6Fz98fBfE+UZSpYw5mJm0NUHtIKrOuNcqeFauy1J6dIvXm2KRVKobOSaGq4t/hBXdN4HGU3wL9Wg==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.6.tgz",
+			"integrity": "sha512-GaTI4nXDrs7l0qaJ6Rg06dtOXTBCG6TMDB44zbqofCIC4PqC7SEvmFFtpxzCDw9W5aJ7RKVshgXTLvLdBFV/qw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.28.5",
-				"@babel/helper-compilation-targets": "^7.27.2",
-				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/compat-data": "^7.28.6",
+				"@babel/helper-compilation-targets": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6",
 				"@babel/helper-validator-option": "^7.27.1",
 				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.28.5",
 				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
 				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
 				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
-				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.3",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.6",
 				"@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-				"@babel/plugin-syntax-import-assertions": "^7.27.1",
-				"@babel/plugin-syntax-import-attributes": "^7.27.1",
+				"@babel/plugin-syntax-import-assertions": "^7.28.6",
+				"@babel/plugin-syntax-import-attributes": "^7.28.6",
 				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
 				"@babel/plugin-transform-arrow-functions": "^7.27.1",
-				"@babel/plugin-transform-async-generator-functions": "^7.28.0",
-				"@babel/plugin-transform-async-to-generator": "^7.27.1",
+				"@babel/plugin-transform-async-generator-functions": "^7.28.6",
+				"@babel/plugin-transform-async-to-generator": "^7.28.6",
 				"@babel/plugin-transform-block-scoped-functions": "^7.27.1",
-				"@babel/plugin-transform-block-scoping": "^7.28.5",
-				"@babel/plugin-transform-class-properties": "^7.27.1",
-				"@babel/plugin-transform-class-static-block": "^7.28.3",
-				"@babel/plugin-transform-classes": "^7.28.4",
-				"@babel/plugin-transform-computed-properties": "^7.27.1",
+				"@babel/plugin-transform-block-scoping": "^7.28.6",
+				"@babel/plugin-transform-class-properties": "^7.28.6",
+				"@babel/plugin-transform-class-static-block": "^7.28.6",
+				"@babel/plugin-transform-classes": "^7.28.6",
+				"@babel/plugin-transform-computed-properties": "^7.28.6",
 				"@babel/plugin-transform-destructuring": "^7.28.5",
-				"@babel/plugin-transform-dotall-regex": "^7.27.1",
+				"@babel/plugin-transform-dotall-regex": "^7.28.6",
 				"@babel/plugin-transform-duplicate-keys": "^7.27.1",
-				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.27.1",
+				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.28.6",
 				"@babel/plugin-transform-dynamic-import": "^7.27.1",
-				"@babel/plugin-transform-explicit-resource-management": "^7.28.0",
-				"@babel/plugin-transform-exponentiation-operator": "^7.28.5",
+				"@babel/plugin-transform-explicit-resource-management": "^7.28.6",
+				"@babel/plugin-transform-exponentiation-operator": "^7.28.6",
 				"@babel/plugin-transform-export-namespace-from": "^7.27.1",
 				"@babel/plugin-transform-for-of": "^7.27.1",
 				"@babel/plugin-transform-function-name": "^7.27.1",
-				"@babel/plugin-transform-json-strings": "^7.27.1",
+				"@babel/plugin-transform-json-strings": "^7.28.6",
 				"@babel/plugin-transform-literals": "^7.27.1",
-				"@babel/plugin-transform-logical-assignment-operators": "^7.28.5",
+				"@babel/plugin-transform-logical-assignment-operators": "^7.28.6",
 				"@babel/plugin-transform-member-expression-literals": "^7.27.1",
 				"@babel/plugin-transform-modules-amd": "^7.27.1",
-				"@babel/plugin-transform-modules-commonjs": "^7.27.1",
+				"@babel/plugin-transform-modules-commonjs": "^7.28.6",
 				"@babel/plugin-transform-modules-systemjs": "^7.28.5",
 				"@babel/plugin-transform-modules-umd": "^7.27.1",
 				"@babel/plugin-transform-named-capturing-groups-regex": "^7.27.1",
 				"@babel/plugin-transform-new-target": "^7.27.1",
-				"@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
-				"@babel/plugin-transform-numeric-separator": "^7.27.1",
-				"@babel/plugin-transform-object-rest-spread": "^7.28.4",
+				"@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6",
+				"@babel/plugin-transform-numeric-separator": "^7.28.6",
+				"@babel/plugin-transform-object-rest-spread": "^7.28.6",
 				"@babel/plugin-transform-object-super": "^7.27.1",
-				"@babel/plugin-transform-optional-catch-binding": "^7.27.1",
-				"@babel/plugin-transform-optional-chaining": "^7.28.5",
+				"@babel/plugin-transform-optional-catch-binding": "^7.28.6",
+				"@babel/plugin-transform-optional-chaining": "^7.28.6",
 				"@babel/plugin-transform-parameters": "^7.27.7",
-				"@babel/plugin-transform-private-methods": "^7.27.1",
-				"@babel/plugin-transform-private-property-in-object": "^7.27.1",
+				"@babel/plugin-transform-private-methods": "^7.28.6",
+				"@babel/plugin-transform-private-property-in-object": "^7.28.6",
 				"@babel/plugin-transform-property-literals": "^7.27.1",
-				"@babel/plugin-transform-regenerator": "^7.28.4",
-				"@babel/plugin-transform-regexp-modifiers": "^7.27.1",
+				"@babel/plugin-transform-regenerator": "^7.28.6",
+				"@babel/plugin-transform-regexp-modifiers": "^7.28.6",
 				"@babel/plugin-transform-reserved-words": "^7.27.1",
 				"@babel/plugin-transform-shorthand-properties": "^7.27.1",
-				"@babel/plugin-transform-spread": "^7.27.1",
+				"@babel/plugin-transform-spread": "^7.28.6",
 				"@babel/plugin-transform-sticky-regex": "^7.27.1",
 				"@babel/plugin-transform-template-literals": "^7.27.1",
 				"@babel/plugin-transform-typeof-symbol": "^7.27.1",
 				"@babel/plugin-transform-unicode-escapes": "^7.27.1",
-				"@babel/plugin-transform-unicode-property-regex": "^7.27.1",
+				"@babel/plugin-transform-unicode-property-regex": "^7.28.6",
 				"@babel/plugin-transform-unicode-regex": "^7.27.1",
-				"@babel/plugin-transform-unicode-sets-regex": "^7.27.1",
+				"@babel/plugin-transform-unicode-sets-regex": "^7.28.6",
 				"@babel/preset-modules": "0.1.6-no-external-plugins",
 				"babel-plugin-polyfill-corejs2": "^0.4.14",
 				"babel-plugin-polyfill-corejs3": "^0.13.0",
@@ -1975,18 +1975,18 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.28.4",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-			"integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+			"integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/runtime-corejs3": {
-			"version": "7.28.4",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.4.tgz",
-			"integrity": "sha512-h7iEYiW4HebClDEhtvFObtPmIvrd1SSfpI9EhOeKk4CtIK/ngBWFpuhCzhdmRKtg71ylcue+9I6dv54XYO1epQ==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.6.tgz",
+			"integrity": "sha512-kz2fAQ5UzjV7X7D3ySxmj3vRq89dTpqOZWv76Z6pNPztkwb/0Yj1Mtx1xFrYj6mbIHysxtBot8J4o0JLCblcFw==",
 			"license": "MIT",
 			"dependencies": {
 				"core-js-pure": "^3.43.0"
@@ -1996,31 +1996,31 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.27.2",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-			"integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+			"integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@babel/parser": "^7.27.2",
-				"@babel/types": "^7.27.1"
+				"@babel/code-frame": "^7.28.6",
+				"@babel/parser": "^7.28.6",
+				"@babel/types": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-			"integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.6.tgz",
+			"integrity": "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.28.5",
+				"@babel/code-frame": "^7.28.6",
+				"@babel/generator": "^7.28.6",
 				"@babel/helper-globals": "^7.28.0",
-				"@babel/parser": "^7.28.5",
-				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.28.5",
+				"@babel/parser": "^7.28.6",
+				"@babel/template": "^7.28.6",
+				"@babel/types": "^7.28.6",
 				"debug": "^4.3.1"
 			},
 			"engines": {
@@ -2028,9 +2028,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-			"integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
+			"integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.27.1",
@@ -3005,9 +3005,9 @@
 			}
 		},
 		"node_modules/@csstools/postcss-normalize-display-values": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.0.tgz",
-			"integrity": "sha512-HlEoG0IDRoHXzXnkV4in47dzsxdsjdz6+j7MLjaACABX2NfvjFS6XVAnpaDyGesz9gK2SC7MbNwdCHusObKJ9Q==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.1.tgz",
+			"integrity": "sha512-TQUGBuRvxdc7TgNSTevYqrL8oItxiwPDixk20qCB5me/W8uF7BPbhRrAvFuhEoywQp/woRsUZ6SJ+sU5idZAIA==",
 			"funding": [
 				{
 					"type": "github",
@@ -4520,6 +4520,18 @@
 				"langium": "3.3.1"
 			}
 		},
+		"node_modules/@noble/hashes": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+			"integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4565,17 +4577,17 @@
 			}
 		},
 		"node_modules/@parcel/watcher": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
-			"integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.4.tgz",
+			"integrity": "sha512-WYa2tUVV5HiArWPB3ydlOc4R2ivq0IDrlqhMi3l7mVsFEXNcTfxYFPIHXHXIh/ca/y/V5N4E1zecyxdIBjYnkQ==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"detect-libc": "^1.0.3",
+				"detect-libc": "^2.0.3",
 				"is-glob": "^4.0.3",
-				"micromatch": "^4.0.5",
-				"node-addon-api": "^7.0.0"
+				"node-addon-api": "^7.0.0",
+				"picomatch": "^4.0.3"
 			},
 			"engines": {
 				"node": ">= 10.0.0"
@@ -4585,25 +4597,25 @@
 				"url": "https://opencollective.com/parcel"
 			},
 			"optionalDependencies": {
-				"@parcel/watcher-android-arm64": "2.5.1",
-				"@parcel/watcher-darwin-arm64": "2.5.1",
-				"@parcel/watcher-darwin-x64": "2.5.1",
-				"@parcel/watcher-freebsd-x64": "2.5.1",
-				"@parcel/watcher-linux-arm-glibc": "2.5.1",
-				"@parcel/watcher-linux-arm-musl": "2.5.1",
-				"@parcel/watcher-linux-arm64-glibc": "2.5.1",
-				"@parcel/watcher-linux-arm64-musl": "2.5.1",
-				"@parcel/watcher-linux-x64-glibc": "2.5.1",
-				"@parcel/watcher-linux-x64-musl": "2.5.1",
-				"@parcel/watcher-win32-arm64": "2.5.1",
-				"@parcel/watcher-win32-ia32": "2.5.1",
-				"@parcel/watcher-win32-x64": "2.5.1"
+				"@parcel/watcher-android-arm64": "2.5.4",
+				"@parcel/watcher-darwin-arm64": "2.5.4",
+				"@parcel/watcher-darwin-x64": "2.5.4",
+				"@parcel/watcher-freebsd-x64": "2.5.4",
+				"@parcel/watcher-linux-arm-glibc": "2.5.4",
+				"@parcel/watcher-linux-arm-musl": "2.5.4",
+				"@parcel/watcher-linux-arm64-glibc": "2.5.4",
+				"@parcel/watcher-linux-arm64-musl": "2.5.4",
+				"@parcel/watcher-linux-x64-glibc": "2.5.4",
+				"@parcel/watcher-linux-x64-musl": "2.5.4",
+				"@parcel/watcher-win32-arm64": "2.5.4",
+				"@parcel/watcher-win32-ia32": "2.5.4",
+				"@parcel/watcher-win32-x64": "2.5.4"
 			}
 		},
 		"node_modules/@parcel/watcher-android-arm64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
-			"integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.4.tgz",
+			"integrity": "sha512-hoh0vx4v+b3BNI7Cjoy2/B0ARqcwVNrzN/n7DLq9ZB4I3lrsvhrkCViJyfTj/Qi5xM9YFiH4AmHGK6pgH1ss7g==",
 			"cpu": [
 				"arm64"
 			],
@@ -4621,9 +4633,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-darwin-arm64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
-			"integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==",
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.4.tgz",
+			"integrity": "sha512-kphKy377pZiWpAOyTgQYPE5/XEKVMaj6VUjKT5VkNyUJlr2qZAn8gIc7CPzx+kbhvqHDT9d7EqdOqRXT6vk0zw==",
 			"cpu": [
 				"arm64"
 			],
@@ -4641,9 +4653,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-darwin-x64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
-			"integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.4.tgz",
+			"integrity": "sha512-UKaQFhCtNJW1A9YyVz3Ju7ydf6QgrpNQfRZ35wNKUhTQ3dxJ/3MULXN5JN/0Z80V/KUBDGa3RZaKq1EQT2a2gg==",
 			"cpu": [
 				"x64"
 			],
@@ -4661,9 +4673,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-freebsd-x64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
-			"integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.4.tgz",
+			"integrity": "sha512-Dib0Wv3Ow/m2/ttvLdeI2DBXloO7t3Z0oCp4bAb2aqyqOjKPPGrg10pMJJAQ7tt8P4V2rwYwywkDhUia/FgS+Q==",
 			"cpu": [
 				"x64"
 			],
@@ -4681,9 +4693,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-arm-glibc": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
-			"integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.4.tgz",
+			"integrity": "sha512-I5Vb769pdf7Q7Sf4KNy8Pogl/URRCKu9ImMmnVKYayhynuyGYMzuI4UOWnegQNa2sGpsPSbzDsqbHNMyeyPCgw==",
 			"cpu": [
 				"arm"
 			],
@@ -4701,9 +4713,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-arm-musl": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
-			"integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.4.tgz",
+			"integrity": "sha512-kGO8RPvVrcAotV4QcWh8kZuHr9bXi9a3bSZw7kFarYR0+fGliU7hd/zevhjw8fnvIKG3J9EO5G6sXNGCSNMYPQ==",
 			"cpu": [
 				"arm"
 			],
@@ -4721,9 +4733,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-arm64-glibc": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
-			"integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.4.tgz",
+			"integrity": "sha512-KU75aooXhqGFY2W5/p8DYYHt4hrjHZod8AhcGAmhzPn/etTa+lYCDB2b1sJy3sWJ8ahFVTdy+EbqSBvMx3iFlw==",
 			"cpu": [
 				"arm64"
 			],
@@ -4741,9 +4753,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-arm64-musl": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
-			"integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.4.tgz",
+			"integrity": "sha512-Qx8uNiIekVutnzbVdrgSanM+cbpDD3boB1f8vMtnuG5Zau4/bdDbXyKwIn0ToqFhIuob73bcxV9NwRm04/hzHQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -4761,9 +4773,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-x64-glibc": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
-			"integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.4.tgz",
+			"integrity": "sha512-UYBQvhYmgAv61LNUn24qGQdjtycFBKSK3EXr72DbJqX9aaLbtCOO8+1SkKhD/GNiJ97ExgcHBrukcYhVjrnogA==",
 			"cpu": [
 				"x64"
 			],
@@ -4781,9 +4793,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-x64-musl": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
-			"integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.4.tgz",
+			"integrity": "sha512-YoRWCVgxv8akZrMhdyVi6/TyoeeMkQ0PGGOf2E4omODrvd1wxniXP+DBynKoHryStks7l+fDAMUBRzqNHrVOpg==",
 			"cpu": [
 				"x64"
 			],
@@ -4801,9 +4813,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-win32-arm64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
-			"integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.4.tgz",
+			"integrity": "sha512-iby+D/YNXWkiQNYcIhg8P5hSjzXEHaQrk2SLrWOUD7VeC4Ohu0WQvmV+HDJokZVJ2UjJ4AGXW3bx7Lls9Ln4TQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -4821,9 +4833,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-win32-ia32": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
-			"integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.4.tgz",
+			"integrity": "sha512-vQN+KIReG0a2ZDpVv8cgddlf67J8hk1WfZMMP7sMeZmJRSmEax5xNDNWKdgqSe2brOKTQQAs3aCCUal2qBHAyg==",
 			"cpu": [
 				"ia32"
 			],
@@ -4841,9 +4853,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-win32-x64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
-			"integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.4.tgz",
+			"integrity": "sha512-3A6efb6BOKwyw7yk9ro2vus2YTt2nvcd56AuzxdMiVOxL9umDyN5PKkKfZ/gZ9row41SjVmTVQNWQhaRRGpOKw==",
 			"cpu": [
 				"x64"
 			],
@@ -4858,6 +4870,167 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/@peculiar/asn1-cms": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.0.tgz",
+			"integrity": "sha512-2uZqP+ggSncESeUF/9Su8rWqGclEfEiz1SyU02WX5fUONFfkjzS2Z/F1Li0ofSmf4JqYXIOdCAZqIXAIBAT1OA==",
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.0",
+				"@peculiar/asn1-x509-attr": "^2.6.0",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-csr": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.6.0.tgz",
+			"integrity": "sha512-BeWIu5VpTIhfRysfEp73SGbwjjoLL/JWXhJ/9mo4vXnz3tRGm+NGm3KNcRzQ9VMVqwYS2RHlolz21svzRXIHPQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.0",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-ecc": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.6.0.tgz",
+			"integrity": "sha512-FF3LMGq6SfAOwUG2sKpPXblibn6XnEIKa+SryvUl5Pik+WR9rmRA3OCiwz8R3lVXnYnyRkSZsSLdml8H3UiOcw==",
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.0",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-pfx": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.6.0.tgz",
+			"integrity": "sha512-rtUvtf+tyKGgokHHmZzeUojRZJYPxoD/jaN1+VAB4kKR7tXrnDCA/RAWXAIhMJJC+7W27IIRGe9djvxKgsldCQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-cms": "^2.6.0",
+				"@peculiar/asn1-pkcs8": "^2.6.0",
+				"@peculiar/asn1-rsa": "^2.6.0",
+				"@peculiar/asn1-schema": "^2.6.0",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-pkcs8": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.6.0.tgz",
+			"integrity": "sha512-KyQ4D8G/NrS7Fw3XCJrngxmjwO/3htnA0lL9gDICvEQ+GJ+EPFqldcJQTwPIdvx98Tua+WjkdKHSC0/Km7T+lA==",
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.0",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-pkcs9": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.6.0.tgz",
+			"integrity": "sha512-b78OQ6OciW0aqZxdzliXGYHASeCvvw5caqidbpQRYW2mBtXIX2WhofNXTEe7NyxTb0P6J62kAAWLwn0HuMF1Fw==",
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-cms": "^2.6.0",
+				"@peculiar/asn1-pfx": "^2.6.0",
+				"@peculiar/asn1-pkcs8": "^2.6.0",
+				"@peculiar/asn1-schema": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.0",
+				"@peculiar/asn1-x509-attr": "^2.6.0",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-rsa": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.6.0.tgz",
+			"integrity": "sha512-Nu4C19tsrTsCp9fDrH+sdcOKoVfdfoQQ7S3VqjJU6vedR7tY3RLkQ5oguOIB3zFW33USDUuYZnPEQYySlgha4w==",
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.0",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-schema": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
+			"integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+			"license": "MIT",
+			"dependencies": {
+				"asn1js": "^3.0.6",
+				"pvtsutils": "^1.3.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-x509": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.0.tgz",
+			"integrity": "sha512-uzYbPEpoQiBoTq0/+jZtpM6Gq6zADBx+JNFP3yqRgziWBxQ/Dt/HcuvRfm9zJTPdRcBqPNdaRHTVwpyiq6iNMA==",
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.6.0",
+				"asn1js": "^3.0.6",
+				"pvtsutils": "^1.3.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-x509-attr": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.0.tgz",
+			"integrity": "sha512-MuIAXFX3/dc8gmoZBkwJWxUWOSvG4MMDntXhrOZpJVMkYX+MYc/rUAU2uJOved9iJEoiUx7//3D8oG83a78UJA==",
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.0",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/x509": {
+			"version": "1.14.3",
+			"resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+			"integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-cms": "^2.6.0",
+				"@peculiar/asn1-csr": "^2.6.0",
+				"@peculiar/asn1-ecc": "^2.6.0",
+				"@peculiar/asn1-pkcs9": "^2.6.0",
+				"@peculiar/asn1-rsa": "^2.6.0",
+				"@peculiar/asn1-schema": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.0",
+				"pvtsutils": "^1.3.6",
+				"reflect-metadata": "^0.2.2",
+				"tslib": "^2.8.1",
+				"tsyringe": "^4.10.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/@pnpm/config.env-replace": {
@@ -5488,9 +5661,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/d3-shape": {
-			"version": "3.1.7",
-			"resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
-			"integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+			"integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/d3-path": "*"
@@ -5590,9 +5763,9 @@
 			}
 		},
 		"node_modules/@types/express-serve-static-core": {
-			"version": "4.19.7",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.7.tgz",
-			"integrity": "sha512-FvPtiIf1LfhzsaIXhv/PHan/2FeQBbtBDtfX2QfvPxdUelMDEckK08SM6nqo1MIZY3RUlfA+HV8+hFUSio78qg==",
+			"version": "4.19.8",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+			"integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*",
@@ -5713,21 +5886,12 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.0.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
-			"integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+			"version": "25.0.8",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.8.tgz",
+			"integrity": "sha512-powIePYMmC3ibL0UJ2i2s0WIbq6cg6UyVFQxSCpaPxxzAaziRfimGivjdF943sSGV6RADVbk0Nvlm5P/FB44Zg==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.16.0"
-			}
-		},
-		"node_modules/@types/node-forge": {
-			"version": "1.3.14",
-			"resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
-			"integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/prismjs": {
@@ -5749,9 +5913,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/react": {
-			"version": "19.2.7",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
-			"integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
+			"version": "19.2.8",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
+			"integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -5897,9 +6061,9 @@
 			"license": "ISC"
 		},
 		"node_modules/@vercel/oidc": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.0.5.tgz",
-			"integrity": "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+			"integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">= 20"
@@ -6175,12 +6339,12 @@
 			}
 		},
 		"node_modules/ai": {
-			"version": "5.0.117",
-			"resolved": "https://registry.npmjs.org/ai/-/ai-5.0.117.tgz",
-			"integrity": "sha512-uE6HNkdSwxbeHGKP/YbvapwD8fMOpj87wyfT9Z00pbzOh2fpnw5acak/4kzU00SX2vtI9K0uuy+9Tf9ytw5RwA==",
+			"version": "5.0.121",
+			"resolved": "https://registry.npmjs.org/ai/-/ai-5.0.121.tgz",
+			"integrity": "sha512-3iYPdARKGLryC/7OA9RgBUaym1gynvWS7UPy8NwoRNCKP52lshldtHB5xcEfVviw7liWH2zJlW9yEzsDglcIEQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@ai-sdk/gateway": "2.0.24",
+				"@ai-sdk/gateway": "2.0.27",
 				"@ai-sdk/provider": "2.0.1",
 				"@ai-sdk/provider-utils": "3.0.20",
 				"@opentelemetry/api": "1.9.0"
@@ -6239,26 +6403,26 @@
 			}
 		},
 		"node_modules/algoliasearch": {
-			"version": "5.46.2",
-			"resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.46.2.tgz",
-			"integrity": "sha512-qqAXW9QvKf2tTyhpDA4qXv1IfBwD2eduSW6tUEBFIfCeE9gn9HQ9I5+MaKoenRuHrzk5sQoNh1/iof8mY7uD6Q==",
+			"version": "5.46.3",
+			"resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.46.3.tgz",
+			"integrity": "sha512-n/NdPglzmkcNYZfIT3Fo8pnDR/lKiK1kZ1Yaa315UoLyHymADhWw15+bzN5gBxrCA8KyeNu0JJD6mLtTov43lQ==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@algolia/abtesting": "1.12.2",
-				"@algolia/client-abtesting": "5.46.2",
-				"@algolia/client-analytics": "5.46.2",
-				"@algolia/client-common": "5.46.2",
-				"@algolia/client-insights": "5.46.2",
-				"@algolia/client-personalization": "5.46.2",
-				"@algolia/client-query-suggestions": "5.46.2",
-				"@algolia/client-search": "5.46.2",
-				"@algolia/ingestion": "1.46.2",
-				"@algolia/monitoring": "1.46.2",
-				"@algolia/recommend": "5.46.2",
-				"@algolia/requester-browser-xhr": "5.46.2",
-				"@algolia/requester-fetch": "5.46.2",
-				"@algolia/requester-node-http": "5.46.2"
+				"@algolia/abtesting": "1.12.3",
+				"@algolia/client-abtesting": "5.46.3",
+				"@algolia/client-analytics": "5.46.3",
+				"@algolia/client-common": "5.46.3",
+				"@algolia/client-insights": "5.46.3",
+				"@algolia/client-personalization": "5.46.3",
+				"@algolia/client-query-suggestions": "5.46.3",
+				"@algolia/client-search": "5.46.3",
+				"@algolia/ingestion": "1.46.3",
+				"@algolia/monitoring": "1.46.3",
+				"@algolia/recommend": "5.46.3",
+				"@algolia/requester-browser-xhr": "5.46.3",
+				"@algolia/requester-fetch": "5.46.3",
+				"@algolia/requester-node-http": "5.46.3"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
@@ -6408,6 +6572,20 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/asn1js": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
+			"integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"pvtsutils": "^1.3.6",
+				"pvutils": "^1.1.3",
+				"tslib": "^2.8.1"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
 		"node_modules/astring": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
@@ -6544,9 +6722,9 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.9.11",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
-			"integrity": "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==",
+			"version": "2.9.14",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.14.tgz",
+			"integrity": "sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==",
 			"license": "Apache-2.0",
 			"bin": {
 				"baseline-browser-mapping": "dist/cli.js"
@@ -6763,6 +6941,15 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/bytestreamjs": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+			"integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/cacheable-lookup": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
@@ -6881,9 +7068,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001762",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001762.tgz",
-			"integrity": "sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==",
+			"version": "1.0.30001764",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001764.tgz",
+			"integrity": "sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -7880,9 +8067,9 @@
 			}
 		},
 		"node_modules/cssdb": {
-			"version": "8.6.0",
-			"resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.6.0.tgz",
-			"integrity": "sha512-7ZrRi/Z3cRL1d5I8RuXEWAkRFP3J4GeQRiyVknI4KC70RAU8hT4LysUZDe0y+fYNOktCbxE8sOPUOhyR12UqGQ==",
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.7.0.tgz",
+			"integrity": "sha512-UxiWVpV953ENHqAKjKRPZHNDfRo3uOymvO5Ef7MFCWlenaohkYj7PTO7WCBdjZm8z/aDZd6rXyUIlwZ0AjyFSg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -8307,9 +8494,9 @@
 			}
 		},
 		"node_modules/d3-format": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-			"integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+			"integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -8758,16 +8945,13 @@
 			}
 		},
 		"node_modules/detect-libc": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-			"integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
 			"license": "Apache-2.0",
 			"optional": true,
-			"bin": {
-				"detect-libc": "bin/detect-libc.js"
-			},
 			"engines": {
-				"node": ">=0.10"
+				"node": ">=8"
 			}
 		},
 		"node_modules/detect-node": {
@@ -12131,9 +12315,9 @@
 			}
 		},
 		"node_modules/memfs": {
-			"version": "4.51.1",
-			"resolved": "https://registry.npmjs.org/memfs/-/memfs-4.51.1.tgz",
-			"integrity": "sha512-Eyt3XrufitN2ZL9c/uIRMyDwXanLI88h/L3MoWqNY747ha3dMR9dWqp8cRT5ntjZ0U1TNuq4U91ZXK0sMBjYOQ==",
+			"version": "4.52.0",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-4.52.0.tgz",
+			"integrity": "sha512-dG5ZY1wUCPWhtl4M2mlc7Wx4OrMGtiI79axnScxwDoPR/25biQYrYm21OpKyZcnKv8pvWaX95SRtZgecZ84gFg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@jsonjoy.com/json-pack": "^1.11.0",
@@ -14212,15 +14396,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/node-forge": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-			"integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
-			"license": "(BSD-3-Clause OR GPL-2.0)",
-			"engines": {
-				"node": ">= 6.13.0"
-			}
-		},
 		"node_modules/node-releases": {
 			"version": "2.0.27",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -14827,6 +15002,23 @@
 				"confbox": "^0.1.8",
 				"mlly": "^1.7.4",
 				"pathe": "^2.0.1"
+			}
+		},
+		"node_modules/pkijs": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.3.3.tgz",
+			"integrity": "sha512-+KD8hJtqQMYoTuL1bbGOqxb4z+nZkTAwVdNtWwe8Tc2xNbEmdJYIYoc6Qt0uF55e6YW6KuTHw1DjQ18gMhzepw==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@noble/hashes": "1.4.0",
+				"asn1js": "^3.0.6",
+				"bytestreamjs": "^2.0.1",
+				"pvtsutils": "^1.3.6",
+				"pvutils": "^1.1.3",
+				"tslib": "^2.8.1"
+			},
+			"engines": {
+				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/points-on-curve": {
@@ -16008,9 +16200,9 @@
 			}
 		},
 		"node_modules/postcss-preset-env": {
-			"version": "10.6.0",
-			"resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.6.0.tgz",
-			"integrity": "sha512-+LzpUSLCGHUdlZ1YZP7lp7w1MjxInJRSG0uaLyk/V/BM17iU2B7xTO7I8x3uk0WQAcLLh/ffqKzOzfaBvG7Fdw==",
+			"version": "10.6.1",
+			"resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.6.1.tgz",
+			"integrity": "sha512-yrk74d9EvY+W7+lO9Aj1QmjWY9q5NsKjK2V9drkOPZB/X6KZ0B3igKsHUYakb7oYVhnioWypQX3xGuePf89f3g==",
 			"funding": [
 				{
 					"type": "github",
@@ -16048,7 +16240,7 @@
 				"@csstools/postcss-media-minmax": "^2.0.9",
 				"@csstools/postcss-media-queries-aspect-ratio-number-values": "^3.0.5",
 				"@csstools/postcss-nested-calc": "^4.0.0",
-				"@csstools/postcss-normalize-display-values": "^4.0.0",
+				"@csstools/postcss-normalize-display-values": "^4.0.1",
 				"@csstools/postcss-oklab-function": "^4.0.12",
 				"@csstools/postcss-position-area-property": "^1.0.0",
 				"@csstools/postcss-progressive-custom-properties": "^4.2.1",
@@ -16443,6 +16635,24 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/pvtsutils": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+			"integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/pvutils": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+			"integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
 		"node_modules/qs": {
 			"version": "6.14.1",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
@@ -16835,6 +17045,12 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
 			}
+		},
+		"node_modules/reflect-metadata": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+			"integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/regenerate": {
 			"version": "1.4.2",
@@ -17394,9 +17610,9 @@
 			"license": "MIT"
 		},
 		"node_modules/sass": {
-			"version": "1.97.1",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.97.1.tgz",
-			"integrity": "sha512-uf6HoO8fy6ClsrShvMgaKUn14f2EHQLQRtpsZZLeU/Mv0Q1K5P0+x2uvH6Cub39TVVbWNSrraUhDAoFph6vh0A==",
+			"version": "1.97.2",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
+			"integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
 			"license": "MIT",
 			"dependencies": {
 				"chokidar": "^4.0.0",
@@ -17482,10 +17698,13 @@
 			}
 		},
 		"node_modules/sax": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
-			"integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
-			"license": "BlueOak-1.0.0"
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
+			"integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=11.0.0"
+			}
 		},
 		"node_modules/scheduler": {
 			"version": "0.27.0",
@@ -17545,16 +17764,16 @@
 			"license": "MIT"
 		},
 		"node_modules/selfsigned": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
-			"integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
+			"integrity": "sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==",
 			"license": "MIT",
 			"dependencies": {
-				"@types/node-forge": "^1.3.0",
-				"node-forge": "^1"
+				"@peculiar/x509": "^1.14.2",
+				"pkijs": "^3.3.3"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			}
 		},
 		"node_modules/semver": {
@@ -18376,9 +18595,9 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.44.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
-			"integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
+			"version": "5.45.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.45.0.tgz",
+			"integrity": "sha512-hQ9c+JZEnMug8eqzuU48sCeq95f00lLDAaJ5gWhRkFXsfy3+SUkZXiF/Z66ZO6EomSmgqXnkhVrWXKaQ8K41Ug==",
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
@@ -18608,6 +18827,24 @@
 			"license": "0BSD",
 			"peer": true
 		},
+		"node_modules/tsyringe": {
+			"version": "4.10.0",
+			"resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+			"integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^1.9.3"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/tsyringe/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"license": "0BSD"
+		},
 		"node_modules/type-fest": {
 			"version": "2.19.0",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
@@ -18664,9 +18901,9 @@
 			}
 		},
 		"node_modules/ufo": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
-			"integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+			"integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
 			"license": "MIT"
 		},
 		"node_modules/undici-types": {
@@ -19227,9 +19464,9 @@
 			"license": "MIT"
 		},
 		"node_modules/watchpack": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.0.tgz",
-			"integrity": "sha512-e6vZvY6xboSwLz2GD36c16+O/2Z6fKvIf4pOXptw2rY9MVwE/TXc6RGqxD3I3x0a28lwBY7DE+76uTPSsBrrCA==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+			"integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
 			"license": "MIT",
 			"dependencies": {
 				"glob-to-regexp": "^0.4.1",
@@ -19406,14 +19643,14 @@
 			}
 		},
 		"node_modules/webpack-dev-server": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
-			"integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.3.tgz",
+			"integrity": "sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/bonjour": "^3.5.13",
 				"@types/connect-history-api-fallback": "^1.5.4",
-				"@types/express": "^4.17.21",
+				"@types/express": "^4.17.25",
 				"@types/express-serve-static-core": "^4.17.21",
 				"@types/serve-index": "^1.9.4",
 				"@types/serve-static": "^1.15.5",
@@ -19423,9 +19660,9 @@
 				"bonjour-service": "^1.2.1",
 				"chokidar": "^3.6.0",
 				"colorette": "^2.0.10",
-				"compression": "^1.7.4",
+				"compression": "^1.8.1",
 				"connect-history-api-fallback": "^2.0.0",
-				"express": "^4.21.2",
+				"express": "^4.22.1",
 				"graceful-fs": "^4.2.6",
 				"http-proxy-middleware": "^2.0.9",
 				"ipaddr.js": "^2.1.0",
@@ -19433,7 +19670,7 @@
 				"open": "^10.0.3",
 				"p-retry": "^6.2.0",
 				"schema-utils": "^4.2.0",
-				"selfsigned": "^2.4.1",
+				"selfsigned": "^5.5.0",
 				"serve-index": "^1.9.1",
 				"sockjs": "^0.3.24",
 				"spdy": "^4.0.2",
@@ -19493,9 +19730,9 @@
 			}
 		},
 		"node_modules/webpack-dev-server/node_modules/ws": {
-			"version": "8.18.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+			"version": "8.19.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"


### PR DESCRIPTION
Update website npm dependencies. Build tested, 0 vulnerabilities.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Broad dependency refresh in `package-lock.json` with no source changes.
> 
> - Upgrades core site deps: `@docusaurus/*` → 3.9.2, `react`/`react-dom` → 19.2.3, `html-react-parser` → 5.2.11, `ai`/`@ai-sdk/*`, `algoliasearch` → 5.46.3, numerous `@babel/*` → 7.28.6
> - Dev/build tooling bumps: `webpack-dev-server` → 5.2.3 (with `selfsigned` → 5.x), `@parcel/watcher` → 2.5.4, `watchpack` → 2.5.1, `sass` → 1.97.2, `terser` → 5.45.0
> - Cryptography stack change: replace `node-forge`/`@types/node-forge` with `@peculiar/x509`, `pkijs`, `asn1js` and related libs
> - Type updates: `@types/node` → 25.0.8, `@types/react` → 19.2.8, misc `@types/*`
> - Lockfile-only dependency updates; no app code modifications
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05359a27b08b88f934f2f29b4c83fd4838a888fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->