### PR TITLE
filter out consensus operations from the `list-ops` command

### DIFF
--- a/cmd/commands/list_ops.go
+++ b/cmd/commands/list_ops.go
@@ -46,6 +46,9 @@ func NewListOps(c *Context) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ops := proto.ListOperations()
 			ops = append(ops, proto.ListPseudoOperations()...)
+			ops = slices.DeleteFunc(ops, func(s string) bool {
+				return s == "InlinedConsensusOperationContent"
+			})
 			slices.Sort(ops)
 			return listOpsTpl.Execute(os.Stdout, ops)
 		},


### PR DESCRIPTION
Follow up https://github.com/ecadlabs/gotez/pull/8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines `list-ops` output to avoid listing consensus-related content.
> 
> - Filters `InlinedConsensusOperationContent` from combined `proto.ListOperations()` + `proto.ListPseudoOperations()` before sorting and rendering
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76584cd80f3b904237c5275a73a0aa2941137bc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->