### PR TITLE
Fix signing_ops_total metric not incrementing for non-generic operations

### DIFF
--- a/integration_test/tests/metrics.go
+++ b/integration_test/tests/metrics.go
@@ -56,13 +56,10 @@ func GetMetrics(address string, kind string, operation string, vault string) Met
 	return metrics
 }
 
-func AssertMetricsSuccessIncremented(t *testing.T, before Metrics, after Metrics, op string) {
+func AssertMetricsSuccessIncremented(t *testing.T, before Metrics, after Metrics) {
 	assert.Greater(t, after.Count, before.Count)
 	assert.Greater(t, after.Sum, before.Sum)
-	// because Issue #376
-	if op == "generic" {
-		assert.Greater(t, after.SigningOpsTotal, before.SigningOpsTotal)
-	}
+	assert.Greater(t, after.SigningOpsTotal, before.SigningOpsTotal)
 	assert.Equal(t, after.Error, before.Error)
 }
 

--- a/integration_test/tests/metrics/metrics_test.go
+++ b/integration_test/tests/metrics/metrics_test.go
@@ -13,5 +13,5 @@ func TestMetrics(t *testing.T) {
 	_, err := integrationtest.OctezClient("transfer", "1", "from", "alice", "to", "bob")
 	require.Nil(t, err)
 	metrics1 := integrationtest.GetMetrics(integrationtest.AlicePKH, "transaction", "generic", "File")
-	integrationtest.AssertMetricsSuccessIncremented(t, metrics0, metrics1, "generic")
+	integrationtest.AssertMetricsSuccessIncremented(t, metrics0, metrics1)
 }

--- a/integration_test/tests/operations/operationkinds_test.go
+++ b/integration_test/tests/operations/operationkinds_test.go
@@ -213,7 +213,7 @@ func TestOperationAllowPolicy(t *testing.T) {
 			assert.NoError(t, err)
 			require.Contains(t, string(out), test.successMessage)
 			metrics2 := integrationtest.GetMetrics(test.account, test.kind, test.op, vault)
-			integrationtest.AssertMetricsSuccessIncremented(t, metrics1, metrics2, test.op)
+			integrationtest.AssertMetricsSuccessIncremented(t, metrics1, metrics2)
 		})
 	}
 }

--- a/pkg/signatory/utils.go
+++ b/pkg/signatory/utils.go
@@ -43,7 +43,10 @@ func getOperationsStat(req *SignRequest, msg core.SignRequest) (operationsStat, 
 			return ops, true
 		}
 	}
-	return nil, false
+	// For non-generic operations (block, attestation, preattestation, etc.),
+	// use SignRequestKind as the operation kind with count of 1
+	ops[msg.SignRequestKind()] = 1
+	return ops, true
 }
 
 func getSignRequest(req *SignRequest) (core.SignRequest, error) {


### PR DESCRIPTION
## Summary

Fixes #376

The `signing_ops_total` metric was not being incremented for non-generic operations (block, attestation, preattestation, etc.).

**Root cause:** `getOperationsStat()` in `pkg/signatory/utils.go` returned `nil, false` for non-generic operations, causing the metric increment to be skipped.

**Fix:** For non-generic operations, return the `SignRequestKind` as the operation kind with count of 1, ensuring the metric is incremented for all operation types.

## Test plan

- [x] Updated `AssertMetricsSuccessIncremented` to verify `signing_ops_total` increments for all operations
- [x] Removed the workaround that only checked this metric for "generic" operations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes `signing_ops_total` not incrementing for non-generic operations.
> 
> - Update `pkg/signatory/utils.go`: `getOperationsStat` now records non-generic ops by setting `ops[msg.SignRequestKind()] = 1` (instead of returning `nil, false`), ensuring metrics are emitted for block/attestation/preattestation/etc.
> - Integration tests: simplify `AssertMetricsSuccessIncremented` (remove `op` param) and always assert `SigningOpsTotal` increments; update usages in `metrics/metrics_test.go` and `operations/operationkinds_test.go`; remove the generic-only workaround.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a249441f727543bc46f84cb76a89445cec90f8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->