### PR TITLE
Clarify website and documentation license

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,33 @@
+Signatory
+Copyright 2018-2026 ECAD Labs Inc.
+
+This product includes software developed by ECAD Labs Inc.
+(https://ecadlabs.com).
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+============================================================================
+WEBSITE AND DOCUMENTATION EXCLUSION NOTICE
+============================================================================
+
+The contents of the "website/" and "docs/" directories and all of their
+subdirectories are NOT covered by the Apache License, Version 2.0. These
+materials, including all documentation, written content, tutorials, guides,
+images, graphics, logos, design assets, and website source code, are the
+exclusive property of ECAD Labs Inc. and are subject to separate proprietary
+licenses. See website/LICENSE and docs/LICENSE for details.
+
+All rights in the website and documentation content are reserved by
+ECAD Labs Inc. No permission is granted to reproduce, distribute, or
+create derivative works of the website and documentation content without
+the prior written consent of ECAD Labs Inc.

--- a/README.md
+++ b/README.md
@@ -153,6 +153,22 @@ For a contribution to be merged, it is required to have complete documentation a
 
 ---
 
+## Licensing
+
+This repository contains materials under two separate licenses:
+
+### Source Code — Apache License 2.0
+
+The Signatory source code (all directories and files in this repository **except** the `website/` and `docs/` directories) is licensed under the [Apache License, Version 2.0](LICENSE). You are free to use, modify, and distribute the source code in accordance with the terms of that license.
+
+### Website & Documentation — Proprietary
+
+The contents of the [`website/`](website/) and [`docs/`](docs/) directories — including all documentation, written content, tutorials, guides, images, graphics, logos, design assets, and website source code — are the **exclusive property of ECAD Labs Inc.** and are **NOT** licensed under Apache 2.0 or any other open-source license. All rights are reserved. See [`website/LICENSE`](website/LICENSE) and [`docs/LICENSE`](docs/LICENSE) for details.
+
+For permissions or licensing inquiries regarding the website and documentation, please contact [info@ecadlabs.com](mailto:info@ecadlabs.com).
+
+---
+
 ## Alternative Remote Signers
 
 At least three other remote signers are available to use with Tezos. Tezos also provides native support for baking with a Ledger Nano. We encourage bakers to, at a minimum, review these projects. We are eager to collaborate and be peers with these great projects.

--- a/docs/LICENSE
+++ b/docs/LICENSE
@@ -1,0 +1,35 @@
+Copyright (c) 2018-2026 ECAD Labs Inc. All rights reserved.
+
+PROPRIETARY LICENSE — SIGNATORY DOCUMENTATION
+
+The contents of this directory ("docs/") and all subdirectories thereof,
+including but not limited to all documentation, written content, tutorials,
+guides, images, graphics, and any other materials contained herein
+(collectively, the "Documentation Content"), are the exclusive property of
+ECAD Labs Inc.
+
+NO LICENSE IS GRANTED. The Documentation Content is NOT licensed under the
+Apache License, Version 2.0, or any other open-source license. The Apache
+License, Version 2.0, which applies to the Signatory source code in this
+repository, expressly does NOT apply to the Documentation Content.
+
+You may NOT, without the prior written permission of ECAD Labs Inc.:
+
+  - Copy, reproduce, or duplicate the Documentation Content;
+  - Distribute, publish, or transmit the Documentation Content;
+  - Create derivative works based on the Documentation Content;
+  - Use the Documentation Content for any commercial or non-commercial purpose;
+  - Sublicense or transfer any rights in the Documentation Content.
+
+The above restrictions apply to all forms of the Documentation Content,
+whether in source form (as contained in this repository) or in
+compiled/published form (as available at https://signatory.io/docs or any
+successor URL).
+
+For permissions, licensing inquiries, or questions, please contact:
+
+  ECAD Labs Inc.
+  info@ecadlabs.com
+
+This notice must be retained in all copies or substantial portions of this
+directory.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,15 @@
+# Signatory Documentation
+
+This directory contains the documentation for [Signatory](https://signatory.io), published at [signatory.io/docs](https://signatory.io/docs).
+
+## License
+
+**This directory is NOT covered by the Apache License, Version 2.0.**
+
+All content in this directory and its subdirectories — including documentation, written content, tutorials, guides, and images — is the exclusive property of **ECAD Labs Inc.** All rights reserved.
+
+See [LICENSE](LICENSE) in this directory for the full proprietary license terms.
+
+## Contact
+
+For permissions or licensing inquiries, contact [info@ecadlabs.com](mailto:info@ecadlabs.com).

--- a/website/LICENSE
+++ b/website/LICENSE
@@ -1,0 +1,35 @@
+Copyright (c) 2018-2026 ECAD Labs Inc. All rights reserved.
+
+PROPRIETARY LICENSE — SIGNATORY WEBSITE AND DOCUMENTATION
+
+The contents of this directory ("website/") and all subdirectories thereof,
+including but not limited to all documentation, written content, tutorials,
+guides, images, graphics, logos, design assets, website source code (HTML,
+CSS, JavaScript, JSX, and related configuration files), and any other
+materials contained herein (collectively, the "Website Content"), are the
+exclusive property of ECAD Labs Inc.
+
+NO LICENSE IS GRANTED. The Website Content is NOT licensed under the Apache
+License, Version 2.0, or any other open-source license. The Apache License,
+Version 2.0, which applies to the Signatory source code in this repository,
+expressly does NOT apply to the Website Content.
+
+You may NOT, without the prior written permission of ECAD Labs Inc.:
+
+  - Copy, reproduce, or duplicate the Website Content;
+  - Distribute, publish, or transmit the Website Content;
+  - Create derivative works based on the Website Content;
+  - Use the Website Content for any commercial or non-commercial purpose;
+  - Sublicense or transfer any rights in the Website Content.
+
+The above restrictions apply to all forms of the Website Content, whether in
+source form (as contained in this repository) or in compiled/published form
+(as available at https://signatory.io or any successor URL).
+
+For permissions, licensing inquiries, or questions, please contact:
+
+  ECAD Labs Inc.
+  info@ecadlabs.com
+
+This notice must be retained in all copies or substantial portions of this
+directory.

--- a/website/README.md
+++ b/website/README.md
@@ -1,33 +1,34 @@
-# Website
+# Signatory Website
 
-This website is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern static website generator.
+This directory contains the source code and content for the [Signatory website](https://signatory.io), built with [Docusaurus](https://docusaurus.io/).
 
-### Installation
+## License
 
-```
-$ yarn
-```
+**This directory is NOT covered by the Apache License, Version 2.0.**
 
-### Local Development
+All content in this directory and its subdirectories — including documentation, written content, tutorials, guides, images, graphics, logos, design assets, and website source code — is the exclusive property of **ECAD Labs Inc.** All rights reserved.
 
-```
-$ yarn start
-```
+See [LICENSE](LICENSE) in this directory for the full proprietary license terms.
 
-This command starts a local development server and open up a browser window. Most changes are reflected live without having to restart the server.
+## Running Locally
 
-### Build
+To run the website locally for development purposes:
 
 ```
-$ yarn build
+yarn install
+yarn start
 ```
 
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
+This command starts a local development server and opens a browser window. Most changes are reflected live without having to restart the server.
 
-### Deployment
+## Build
 
 ```
-$ GIT_USER=<Your GitHub username> USE_SSH=true yarn deploy
+yarn build
 ```
 
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+This command generates static content into the `build` directory.
+
+## Contact
+
+For permissions or licensing inquiries, contact [info@ecadlabs.com](mailto:info@ecadlabs.com).

--- a/website/src/theme/Footer/index.js
+++ b/website/src/theme/Footer/index.js
@@ -187,7 +187,7 @@ function Footer() {
 				)}
 			</div>
 			<div className='footer__copyright'>
-				{`Copyright © ${new Date().getFullYear()} ECAD Labs - Apache License 2.0`}
+				{`Copyright © ${new Date().getFullYear()} ECAD Labs Inc. All rights reserved.`}
 			</div>
 		</footer>
 	);


### PR DESCRIPTION
## Summary

Establishes dual licensing for the Signatory repository (mirrors approach from Taquito PR ecadlabs/taquito#3322):

- **Source code**: Apache License 2.0 (unchanged)
- **Website & documentation**: Proprietary, all rights reserved by ECAD Labs Inc.

## Changes

- Add `website/LICENSE` with proprietary license terms
- Add `docs/LICENSE` with proprietary license terms
- Create `NOTICE` file with website and documentation exclusion notice
- Add licensing section to `README.md`
- Update `website/README.md` with licensing notice
- Add `docs/README.md` with licensing notice
- Update website footer copyright to "All rights reserved"

## Test plan

- [ ] Verify all modified files contain correct content
- [ ] Confirm GitHub license detection picks up directory-level LICENSE files
- [ ] Review website footer displays updated copyright

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/legal text and a small footer string change; no runtime behavior changes to the signer or security-sensitive logic.
> 
> **Overview**
> Establishes **dual licensing** for the repository by adding a root `NOTICE` that excludes `website/` and `docs/` from Apache 2.0 coverage and introducing proprietary license files for those directories.
> 
> Updates `README.md`, `website/README.md`, and a new `docs/README.md` to clearly communicate the split licensing and contact info, and adjusts the website footer copyright text to **“All rights reserved.”**
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1105a3e5e0335b016ec191126d233b0bcd29fd5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->