### PR TITLE
fix: allow ballot sub-kinds (yay/nay/pass) in operation kind validation

### DIFF
--- a/pkg/signatory/signatory.go
+++ b/pkg/signatory/signatory.go
@@ -713,6 +713,30 @@ func checkRequestKind(allowedKinds []string) error {
 func checkOperationKind(allowedKinds []string) error {
 	avilKinds := append(proto.ListGenericOperations(), proto.ListPseudoOperations()...)
 	for _, kind := range allowedKinds {
+		// Handle ballot sub-kinds (ballot:yay, ballot:nay, ballot:pass)
+		if strings.Contains(kind, ":") {
+			parts := strings.SplitN(kind, ":", 2)
+			base := parts[0]
+			subKind := parts[1]
+			
+			// Only ballot operations support sub-kind syntax
+			if base != "ballot" {
+				return fmt.Errorf("invalid operation kind `%s` in `allow.generic` list", kind)
+			}
+			
+			// Validate the ballot sub-kind
+			validBallotKinds := []string{"yay", "nay", "pass"}
+			if !slices.Contains(validBallotKinds, subKind) {
+				return fmt.Errorf("invalid operation kind `%s` in `allow.generic` list", kind)
+			}
+			
+			// Ensure base "ballot" is in the valid operations list
+			if !slices.Contains(avilKinds, base) {
+				return fmt.Errorf("invalid operation kind `%s` in `allow.generic` list", kind)
+			}
+			continue
+		}
+		
 		if !slices.Contains(avilKinds, kind) {
 			return fmt.Errorf("invalid operation kind `%s` in `allow.generic` list", kind)
 		}

--- a/pkg/signatory/signatory_test.go
+++ b/pkg/signatory/signatory_test.go
@@ -817,6 +817,28 @@ func TestOperationKindCheck(t *testing.T) {
 				"ballot",
 			},
 		},
+		{
+			name: "ballot:yay accepted",
+			ops:  []string{"ballot:yay"},
+		},
+		{
+			name: "ballot:nay accepted",
+			ops:  []string{"ballot:nay"},
+		},
+		{
+			name: "ballot:pass accepted",
+			ops:  []string{"ballot:pass"},
+		},
+		{
+			name:    "ballot:invalid rejected",
+			ops:     []string{"ballot:invalid"},
+			wantErr: "invalid operation kind `ballot:invalid` in `allow.generic` list",
+		},
+		{
+			name:    "transaction:foo rejected",
+			ops:     []string{"transaction:foo"},
+			wantErr: "invalid operation kind `transaction:foo` in `allow.generic` list",
+		},
 	}
 
 	invalidOps := []string{"attestation", "attestation_with_dal", "preattestation"}


### PR DESCRIPTION
Hey, while debugging https://github.com/ecadlabs/gotez/pull/13 I noticed this regression between 1.3.0 and 1.3.1.  I used git bisect and it came down to https://github.com/ecadlabs/signatory/pull/657. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to configuration validation plus tests; low risk aside from potentially changing behavior for configs that previously (incorrectly) used `:` in operation kinds.
> 
> **Overview**
> Fixes policy validation to accept ballot sub-kinds in `allow.generic` using `ballot:yay`, `ballot:nay`, and `ballot:pass` syntax, while still rejecting `kind:subkind` for non-ballot operations and invalid ballot values.
> 
> Adds unit tests for the new ballot sub-kind validation, including negative cases for invalid sub-kinds and unsupported `op:sub` formats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecbdc35fd7282ce8a47977b461bfd2e119c34432. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->