### PR TITLE
Update website dependencies

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -22,86 +22,16 @@
 				"react-use-mailchimp-signup": "^2.0.2"
 			}
 		},
-		"node_modules/@ai-sdk/gateway": {
-			"version": "2.0.27",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.27.tgz",
-			"integrity": "sha512-8hbezMsGa0crSt7/DKjkYL1UbbJJW/UFxTfhmf5qcIeYeeWG4dTNmm+DWbUdIsTaWvp59KC4eeC9gYXBbTHd7w==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@ai-sdk/provider": "2.0.1",
-				"@ai-sdk/provider-utils": "3.0.20",
-				"@vercel/oidc": "3.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"zod": "^3.25.76 || ^4.1.8"
-			}
-		},
-		"node_modules/@ai-sdk/provider": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.1.tgz",
-			"integrity": "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"json-schema": "^0.4.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@ai-sdk/provider-utils": {
-			"version": "3.0.20",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.20.tgz",
-			"integrity": "sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@ai-sdk/provider": "2.0.1",
-				"@standard-schema/spec": "^1.0.0",
-				"eventsource-parser": "^3.0.6"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"zod": "^3.25.76 || ^4.1.8"
-			}
-		},
-		"node_modules/@ai-sdk/react": {
-			"version": "2.0.123",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-2.0.123.tgz",
-			"integrity": "sha512-exaEvHAsDdR0wgzF3l0BmC9U1nPLnkPK2CCnX3BP4RDj/PySZvPXjry3AOz1Ayb8KSPZgWklVRzxsQxrOYQJxA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@ai-sdk/provider-utils": "3.0.20",
-				"ai": "5.0.121",
-				"swr": "^2.2.5",
-				"throttleit": "2.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1",
-				"zod": "^3.25.76 || ^4.1.8"
-			},
-			"peerDependenciesMeta": {
-				"zod": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@algolia/abtesting": {
-			"version": "1.12.3",
-			"resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.12.3.tgz",
-			"integrity": "sha512-0SpSdnME0RCS6UHSs9XD3ox4bMcCg1JTmjAJ3AU6rcTlX54CZOAEPc2as8uSghX6wfKGT0HWes4TeUpjJMg6FQ==",
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.15.1.tgz",
+			"integrity": "sha512-2yuIC48rUuHGhU1U5qJ9kJHaxYpJ0jpDHJVI5ekOxSMYXlH4+HP+pA31G820lsAznfmu2nzDV7n5RO44zIY1zw==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3",
-				"@algolia/requester-browser-xhr": "5.46.3",
-				"@algolia/requester-fetch": "5.46.3",
-				"@algolia/requester-node-http": "5.46.3"
+				"@algolia/client-common": "5.49.1",
+				"@algolia/requester-browser-xhr": "5.49.1",
+				"@algolia/requester-fetch": "5.49.1",
+				"@algolia/requester-node-http": "5.49.1"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
@@ -140,100 +70,99 @@
 			}
 		},
 		"node_modules/@algolia/client-abtesting": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.46.3.tgz",
-			"integrity": "sha512-i2C8sBcl3EKXuCd5nlGohW+pZ9pY3P3JKJ2OYqsbCPg6wURiR32hNDiDvDq7/dqJ7KWWwC2snxJhokZzGlckgQ==",
+			"version": "5.49.1",
+			"resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.49.1.tgz",
+			"integrity": "sha512-h6M7HzPin+45/l09q0r2dYmocSSt2MMGOOk5c4O5K/bBBlEwf1BKfN6z+iX4b8WXcQQhf7rgQwC52kBZJt/ZZw==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3",
-				"@algolia/requester-browser-xhr": "5.46.3",
-				"@algolia/requester-fetch": "5.46.3",
-				"@algolia/requester-node-http": "5.46.3"
+				"@algolia/client-common": "5.49.1",
+				"@algolia/requester-browser-xhr": "5.49.1",
+				"@algolia/requester-fetch": "5.49.1",
+				"@algolia/requester-node-http": "5.49.1"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-analytics": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.46.3.tgz",
-			"integrity": "sha512-uFmD7m3LOym1SAURHeiqupHT9jui+9HK0lAiIvm077gXEscOM5KKXM4rg/ICzQ3UDHLZEA0Lb5TglWsXnieE6w==",
+			"version": "5.49.1",
+			"resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.49.1.tgz",
+			"integrity": "sha512-048T9/Z8OeLmTk8h76QUqaNFp7Rq2VgS2Zm6Y2tNMYGQ1uNuzePY/udB5l5krlXll7ZGflyCjFvRiOtlPZpE9g==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3",
-				"@algolia/requester-browser-xhr": "5.46.3",
-				"@algolia/requester-fetch": "5.46.3",
-				"@algolia/requester-node-http": "5.46.3"
+				"@algolia/client-common": "5.49.1",
+				"@algolia/requester-browser-xhr": "5.49.1",
+				"@algolia/requester-fetch": "5.49.1",
+				"@algolia/requester-node-http": "5.49.1"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-common": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.46.3.tgz",
-			"integrity": "sha512-SN+yK840nXa+2+mF72hrDfGd8+B7eBjF8TK/8KoRMdjlAkO/P3o3vtpjKRKI/Sk4L8kYYkB/avW8l+cwR+O1Ew==",
+			"version": "5.49.1",
+			"resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.49.1.tgz",
+			"integrity": "sha512-vp5/a9ikqvf3mn9QvHN8PRekn8hW34aV9eX+O0J5mKPZXeA6Pd5OQEh2ZWf7gJY6yyfTlLp5LMFzQUAU+Fpqpg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-insights": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.46.3.tgz",
-			"integrity": "sha512-5ic1liG0VucNPi6gKCWh5bEUGWQfyEmVeXiNKS+rOSppg7B7nKH0PEEJOFXBbHmgK5aPfNNZINiKcyUoH4XsFA==",
+			"version": "5.49.1",
+			"resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.49.1.tgz",
+			"integrity": "sha512-B6N7PgkvYrul3bntTz/l6uXnhQ2bvP+M7NqTcayh681tSqPaA5cJCUBp/vrP7vpPRpej4Eeyx2qz5p0tE/2N2g==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3",
-				"@algolia/requester-browser-xhr": "5.46.3",
-				"@algolia/requester-fetch": "5.46.3",
-				"@algolia/requester-node-http": "5.46.3"
+				"@algolia/client-common": "5.49.1",
+				"@algolia/requester-browser-xhr": "5.49.1",
+				"@algolia/requester-fetch": "5.49.1",
+				"@algolia/requester-node-http": "5.49.1"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-personalization": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.46.3.tgz",
-			"integrity": "sha512-f4HNitgTip8tntKgluYBTc1LWSOkbNCdxZvRA3rRBZnEAYSvLe7jpE+AxRep6RY+prSWwMtyeCFhA/F1Um+TuQ==",
+			"version": "5.49.1",
+			"resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.49.1.tgz",
+			"integrity": "sha512-v+4DN+lkYfBd01Hbnb9ZrCHe7l+mvihyx218INRX/kaCXROIWUDIT1cs3urQxfE7kXBFnLsqYeOflQALv/gA5w==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3",
-				"@algolia/requester-browser-xhr": "5.46.3",
-				"@algolia/requester-fetch": "5.46.3",
-				"@algolia/requester-node-http": "5.46.3"
+				"@algolia/client-common": "5.49.1",
+				"@algolia/requester-browser-xhr": "5.49.1",
+				"@algolia/requester-fetch": "5.49.1",
+				"@algolia/requester-node-http": "5.49.1"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-query-suggestions": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.46.3.tgz",
-			"integrity": "sha512-/AaVqah2aYyJj7Cazu5QRkgcV3HF3lkBJo5TRkgqQ26xR4iHNRbLF2YsWJfJpJEFghlTF2HOCh7IgzaUCnM+8A==",
+			"version": "5.49.1",
+			"resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.49.1.tgz",
+			"integrity": "sha512-Un11cab6ZCv0W+Jiak8UktGIqoa4+gSNgEZNfG8m8eTsXGqwIEr370H3Rqwj87zeNSlFpH2BslMXJ/cLNS1qtg==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3",
-				"@algolia/requester-browser-xhr": "5.46.3",
-				"@algolia/requester-fetch": "5.46.3",
-				"@algolia/requester-node-http": "5.46.3"
+				"@algolia/client-common": "5.49.1",
+				"@algolia/requester-browser-xhr": "5.49.1",
+				"@algolia/requester-fetch": "5.49.1",
+				"@algolia/requester-node-http": "5.49.1"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-search": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.46.3.tgz",
-			"integrity": "sha512-hfpCIukPuwkrlwsYfJEWdU5R5bduBHEq2uuPcqmgPgNq5MSjmiNIzRuzxGZZgiBKcre6gZT00DR7G1AFn//wiQ==",
+			"version": "5.49.1",
+			"resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.49.1.tgz",
+			"integrity": "sha512-Nt9hri7nbOo0RipAsGjIssHkpLMHHN/P7QqENywAq5TLsoYDzUyJGny8FEiD/9KJUxtGH8blGpMedilI6kK3rA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@algolia/client-common": "5.46.3",
-				"@algolia/requester-browser-xhr": "5.46.3",
-				"@algolia/requester-fetch": "5.46.3",
-				"@algolia/requester-node-http": "5.46.3"
+				"@algolia/client-common": "5.49.1",
+				"@algolia/requester-browser-xhr": "5.49.1",
+				"@algolia/requester-fetch": "5.49.1",
+				"@algolia/requester-node-http": "5.49.1"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
@@ -246,81 +175,81 @@
 			"license": "MIT"
 		},
 		"node_modules/@algolia/ingestion": {
-			"version": "1.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.46.3.tgz",
-			"integrity": "sha512-ChVzNkCzAVxKozTnTgPWCG69WQLjzW7X6OqD91zUh8U38ZhPEX/t3qGhXs+M9ZNaHcJ7xToMB3jywNwONhpLGA==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.49.1.tgz",
+			"integrity": "sha512-b5hUXwDqje0Y4CpU6VL481DXgPgxpTD5sYMnfQTHKgUispGnaCLCm2/T9WbJo1YNUbX3iHtYDArp804eD6CmRQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3",
-				"@algolia/requester-browser-xhr": "5.46.3",
-				"@algolia/requester-fetch": "5.46.3",
-				"@algolia/requester-node-http": "5.46.3"
+				"@algolia/client-common": "5.49.1",
+				"@algolia/requester-browser-xhr": "5.49.1",
+				"@algolia/requester-fetch": "5.49.1",
+				"@algolia/requester-node-http": "5.49.1"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/monitoring": {
-			"version": "1.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.46.3.tgz",
-			"integrity": "sha512-MZa+Z5iPmVMxVAQ0aq4HpGsja5utSLEMcOuY01X8D46vvMrSPkP8DnlDFtu1PgJ0RwyIGqqx7v+ClFo6iRJ6bA==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.49.1.tgz",
+			"integrity": "sha512-bvrXwZ0WsL3rN6Q4m4QqxsXFCo6WAew7sAdrpMQMK4Efn4/W920r9ptOuckejOSSvyLr9pAWgC5rsHhR2FYuYw==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3",
-				"@algolia/requester-browser-xhr": "5.46.3",
-				"@algolia/requester-fetch": "5.46.3",
-				"@algolia/requester-node-http": "5.46.3"
+				"@algolia/client-common": "5.49.1",
+				"@algolia/requester-browser-xhr": "5.49.1",
+				"@algolia/requester-fetch": "5.49.1",
+				"@algolia/requester-node-http": "5.49.1"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/recommend": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.46.3.tgz",
-			"integrity": "sha512-cr3atJRJBKgAKZl/Oxo4sig6Se0+ukbyIOOluPV5H+ZAXVcxuMoXQgwQ1M5UHPnCnEsZ4uBXhBmilRgUQpUegw==",
+			"version": "5.49.1",
+			"resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.49.1.tgz",
+			"integrity": "sha512-h2yz3AGeGkQwNgbLmoe3bxYs8fac4An1CprKTypYyTU/k3Q+9FbIvJ8aS1DoBKaTjSRZVoyQS7SZQio6GaHbZw==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3",
-				"@algolia/requester-browser-xhr": "5.46.3",
-				"@algolia/requester-fetch": "5.46.3",
-				"@algolia/requester-node-http": "5.46.3"
+				"@algolia/client-common": "5.49.1",
+				"@algolia/requester-browser-xhr": "5.49.1",
+				"@algolia/requester-fetch": "5.49.1",
+				"@algolia/requester-node-http": "5.49.1"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/requester-browser-xhr": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.46.3.tgz",
-			"integrity": "sha512-/Ku9GImJf2SKoRM2S3e03MjCVaWJCP5olih4k54DRhNDdmxBkd3nsWuUXvDElY3Ucw/arBYGs5SYz79SoS5APw==",
+			"version": "5.49.1",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.49.1.tgz",
+			"integrity": "sha512-2UPyRuUR/qpqSqH8mxFV5uBZWEpxhGPHLlx9Xf6OVxr79XO2ctzZQAhsmTZ6X22x+N8MBWpB9UEky7YU2HGFgA==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3"
+				"@algolia/client-common": "5.49.1"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/requester-fetch": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.46.3.tgz",
-			"integrity": "sha512-Uw+SPy/zpfwbH1AxQaeOWvWVzPEcO0XbtLbbSz0HPcEIiBGWyfa9LUCxD5UferbDjrSQNVimmzl3FaWi4u8Ykw==",
+			"version": "5.49.1",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.49.1.tgz",
+			"integrity": "sha512-N+xlE4lN+wpuT+4vhNEwPVlrfN+DWAZmSX9SYhbz986Oq8AMsqdntOqUyiOXVxYsQtfLwmiej24vbvJGYv1Qtw==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3"
+				"@algolia/client-common": "5.49.1"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/requester-node-http": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.46.3.tgz",
-			"integrity": "sha512-4No9iTjr1GZ0JWsFbQJj9aZBnmKyY1sTxOoEud9+SGe3U6iAulF0A0lI4cWi/F/Gcfg8V3jkaddcqSQKDnE45w==",
+			"version": "5.49.1",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.49.1.tgz",
+			"integrity": "sha512-zA5bkUOB5PPtTr182DJmajCiizHp0rCJQ0Chf96zNFvkdESKYlDeYA3tQ7r2oyHbu/8DiohAQ5PZ85edctzbXA==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3"
+				"@algolia/client-common": "5.49.1"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
@@ -340,9 +269,9 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.28.6.tgz",
-			"integrity": "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.28.5",
@@ -354,30 +283,29 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.6.tgz",
-			"integrity": "sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+			"integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
-			"integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.28.6",
-				"@babel/generator": "^7.28.6",
+				"@babel/code-frame": "^7.29.0",
+				"@babel/generator": "^7.29.0",
 				"@babel/helper-compilation-targets": "^7.28.6",
 				"@babel/helper-module-transforms": "^7.28.6",
 				"@babel/helpers": "^7.28.6",
-				"@babel/parser": "^7.28.6",
+				"@babel/parser": "^7.29.0",
 				"@babel/template": "^7.28.6",
-				"@babel/traverse": "^7.28.6",
-				"@babel/types": "^7.28.6",
+				"@babel/traverse": "^7.29.0",
+				"@babel/types": "^7.29.0",
 				"@jridgewell/remapping": "^2.3.5",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
@@ -403,13 +331,13 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.6.tgz",
-			"integrity": "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==",
+			"version": "7.29.1",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+			"integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.28.6",
-				"@babel/types": "^7.28.6",
+				"@babel/parser": "^7.29.0",
+				"@babel/types": "^7.29.0",
 				"@jridgewell/gen-mapping": "^0.3.12",
 				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
@@ -512,16 +440,16 @@
 			}
 		},
 		"node_modules/@babel/helper-define-polyfill-provider": {
-			"version": "0.6.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.5.tgz",
-			"integrity": "sha512-uJnGFcPsWQK8fvjgGP5LZUZZsYGIoPeRjSF5PGwrelYgq7Q15/Ft9NGFp1zglwgIv//W0uG4BevRuSJRyylZPg==",
+			"version": "0.6.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.6.tgz",
+			"integrity": "sha512-mOAsxeeKkUKayvZR3HeTYD/fICpCPLJrU5ZjelT/PA6WHtNDBOE436YiaEUvHN454bRM3CebhDsIpieCc4texA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.27.2",
-				"@babel/helper-plugin-utils": "^7.27.1",
-				"debug": "^4.4.1",
+				"@babel/helper-compilation-targets": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6",
+				"debug": "^4.4.3",
 				"lodash.debounce": "^4.0.8",
-				"resolve": "^1.22.10"
+				"resolve": "^1.22.11"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -702,12 +630,12 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
-			"integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+			"integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.28.6"
+				"@babel/types": "^7.29.0"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -911,14 +839,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-generator-functions": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.6.tgz",
-			"integrity": "sha512-9knsChgsMzBV5Yh3kkhrZNxH3oCYAfMBkNNaVN4cP2RVlFPe8wYdwwcnOsAbkdDoV9UjFtOXWrWB52M8W4jNeA==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.0.tgz",
+			"integrity": "sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.28.6",
 				"@babel/helper-remap-async-to-generator": "^7.27.1",
-				"@babel/traverse": "^7.28.6"
+				"@babel/traverse": "^7.29.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1090,9 +1018,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.28.6.tgz",
-			"integrity": "sha512-5suVoXjC14lUN6ZL9OLKIHCNVWCrqGqlmEp/ixdXjvgnEl/kauLvvMO/Xw9NyMc95Joj1AeLVPVMvibBgSoFlA==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.0.tgz",
+			"integrity": "sha512-zBPcW2lFGxdiD8PUnPwJjag2J9otbcLQzvbiOzDxpYXyCuYX9agOwMPGn1prVH0a4qzhCKu24rlH4c1f7yA8rw==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-create-regexp-features-plugin": "^7.28.5",
@@ -1292,15 +1220,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-systemjs": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.28.5.tgz",
-			"integrity": "sha512-vn5Jma98LCOeBy/KpeQhXcV2WZgaRUtjwQmjoBuLNlOmkg0fB5pdvYVeWRYI69wWKwK2cD1QbMiUQnoujWvrew==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
+			"integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.28.3",
-				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-module-transforms": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6",
 				"@babel/helper-validator-identifier": "^7.28.5",
-				"@babel/traverse": "^7.28.5"
+				"@babel/traverse": "^7.29.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1326,13 +1254,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.27.1.tgz",
-			"integrity": "sha512-SstR5JYy8ddZvD6MhV0tM/j16Qds4mIpJTOd1Yu9J9pJjH93bxHECF7pgtc28XvkzTD6Pxcm/0Z73Hvk7kb3Ng==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.0.tgz",
+			"integrity": "sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-create-regexp-features-plugin": "^7.28.5",
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1596,9 +1524,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-regenerator": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.6.tgz",
-			"integrity": "sha512-eZhoEZHYQLL5uc1gS5e9/oTknS0sSSAtd5TkKMUp3J+S/CaUjagc0kOUPsEbDmMeva0nC3WWl4SxVY6+OBuxfw==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.0.tgz",
+			"integrity": "sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.28.6"
@@ -1642,13 +1570,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-runtime": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.28.5.tgz",
-			"integrity": "sha512-20NUVgOrinudkIBzQ2bNxP08YpKprUkRTiRSd2/Z5GOdPImJGkoN4Z7IQe1T5AdyKI1i5L6RBmluqdSzvaq9/w==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.29.0.tgz",
+			"integrity": "sha512-jlaRT5dJtMaMCV6fAuLbsQMSwz/QkvaHOHOSXRitGGwSpR1blCY4KUKoyP2tYO8vJcqYe8cEj96cqSztv3uF9w==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-module-imports": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6",
 				"babel-plugin-polyfill-corejs2": "^0.4.14",
 				"babel-plugin-polyfill-corejs3": "^0.13.0",
 				"babel-plugin-polyfill-regenerator": "^0.6.5",
@@ -1829,12 +1757,12 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.6.tgz",
-			"integrity": "sha512-GaTI4nXDrs7l0qaJ6Rg06dtOXTBCG6TMDB44zbqofCIC4PqC7SEvmFFtpxzCDw9W5aJ7RKVshgXTLvLdBFV/qw==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.0.tgz",
+			"integrity": "sha512-fNEdfc0yi16lt6IZo2Qxk3knHVdfMYX33czNb4v8yWhemoBhibCpQK/uYHtSKIiO+p/zd3+8fYVXhQdOVV608w==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.28.6",
+				"@babel/compat-data": "^7.29.0",
 				"@babel/helper-compilation-targets": "^7.28.6",
 				"@babel/helper-plugin-utils": "^7.28.6",
 				"@babel/helper-validator-option": "^7.27.1",
@@ -1848,7 +1776,7 @@
 				"@babel/plugin-syntax-import-attributes": "^7.28.6",
 				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
 				"@babel/plugin-transform-arrow-functions": "^7.27.1",
-				"@babel/plugin-transform-async-generator-functions": "^7.28.6",
+				"@babel/plugin-transform-async-generator-functions": "^7.29.0",
 				"@babel/plugin-transform-async-to-generator": "^7.28.6",
 				"@babel/plugin-transform-block-scoped-functions": "^7.27.1",
 				"@babel/plugin-transform-block-scoping": "^7.28.6",
@@ -1859,7 +1787,7 @@
 				"@babel/plugin-transform-destructuring": "^7.28.5",
 				"@babel/plugin-transform-dotall-regex": "^7.28.6",
 				"@babel/plugin-transform-duplicate-keys": "^7.27.1",
-				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.28.6",
+				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.0",
 				"@babel/plugin-transform-dynamic-import": "^7.27.1",
 				"@babel/plugin-transform-explicit-resource-management": "^7.28.6",
 				"@babel/plugin-transform-exponentiation-operator": "^7.28.6",
@@ -1872,9 +1800,9 @@
 				"@babel/plugin-transform-member-expression-literals": "^7.27.1",
 				"@babel/plugin-transform-modules-amd": "^7.27.1",
 				"@babel/plugin-transform-modules-commonjs": "^7.28.6",
-				"@babel/plugin-transform-modules-systemjs": "^7.28.5",
+				"@babel/plugin-transform-modules-systemjs": "^7.29.0",
 				"@babel/plugin-transform-modules-umd": "^7.27.1",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.27.1",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.29.0",
 				"@babel/plugin-transform-new-target": "^7.27.1",
 				"@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6",
 				"@babel/plugin-transform-numeric-separator": "^7.28.6",
@@ -1886,7 +1814,7 @@
 				"@babel/plugin-transform-private-methods": "^7.28.6",
 				"@babel/plugin-transform-private-property-in-object": "^7.28.6",
 				"@babel/plugin-transform-property-literals": "^7.27.1",
-				"@babel/plugin-transform-regenerator": "^7.28.6",
+				"@babel/plugin-transform-regenerator": "^7.29.0",
 				"@babel/plugin-transform-regexp-modifiers": "^7.28.6",
 				"@babel/plugin-transform-reserved-words": "^7.27.1",
 				"@babel/plugin-transform-shorthand-properties": "^7.27.1",
@@ -1899,10 +1827,10 @@
 				"@babel/plugin-transform-unicode-regex": "^7.27.1",
 				"@babel/plugin-transform-unicode-sets-regex": "^7.28.6",
 				"@babel/preset-modules": "0.1.6-no-external-plugins",
-				"babel-plugin-polyfill-corejs2": "^0.4.14",
-				"babel-plugin-polyfill-corejs3": "^0.13.0",
-				"babel-plugin-polyfill-regenerator": "^0.6.5",
-				"core-js-compat": "^3.43.0",
+				"babel-plugin-polyfill-corejs2": "^0.4.15",
+				"babel-plugin-polyfill-corejs3": "^0.14.0",
+				"babel-plugin-polyfill-regenerator": "^0.6.6",
+				"core-js-compat": "^3.48.0",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -1910,6 +1838,19 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/preset-env/node_modules/babel-plugin-polyfill-corejs3": {
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.0.tgz",
+			"integrity": "sha512-AvDcMxJ34W4Wgy4KBIIePQTAOP1Ie2WFwkQp3dB7FQ/f0lI5+nM96zUnYEOE1P9sEg0es5VCP0HxiWu5fUHZAQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-define-polyfill-provider": "^0.6.6",
+				"core-js-compat": "^3.48.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
 			}
 		},
 		"node_modules/@babel/preset-env/node_modules/semver": {
@@ -1984,12 +1925,12 @@
 			}
 		},
 		"node_modules/@babel/runtime-corejs3": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.6.tgz",
-			"integrity": "sha512-kz2fAQ5UzjV7X7D3ySxmj3vRq89dTpqOZWv76Z6pNPztkwb/0Yj1Mtx1xFrYj6mbIHysxtBot8J4o0JLCblcFw==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.0.tgz",
+			"integrity": "sha512-TgUkdp71C9pIbBcHudc+gXZnihEDOjUAmXO1VO4HHGES7QLZcShR0stfKIxLSNIYx2fqhmJChOjm/wkF8wv4gA==",
 			"license": "MIT",
 			"dependencies": {
-				"core-js-pure": "^3.43.0"
+				"core-js-pure": "^3.48.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2010,17 +1951,17 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.6.tgz",
-			"integrity": "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+			"integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.28.6",
-				"@babel/generator": "^7.28.6",
+				"@babel/code-frame": "^7.29.0",
+				"@babel/generator": "^7.29.0",
 				"@babel/helper-globals": "^7.28.0",
-				"@babel/parser": "^7.28.6",
+				"@babel/parser": "^7.29.0",
 				"@babel/template": "^7.28.6",
-				"@babel/types": "^7.28.6",
+				"@babel/types": "^7.29.0",
 				"debug": "^4.3.1"
 			},
 			"engines": {
@@ -2028,9 +1969,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
-			"integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.27.1",
@@ -2041,60 +1982,48 @@
 			}
 		},
 		"node_modules/@braintree/sanitize-url": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.1.tgz",
-			"integrity": "sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+			"integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
 			"license": "MIT"
 		},
 		"node_modules/@chevrotain/cst-dts-gen": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
-			"integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.1.2.tgz",
+			"integrity": "sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@chevrotain/gast": "11.0.3",
-				"@chevrotain/types": "11.0.3",
-				"lodash-es": "4.17.21"
+				"@chevrotain/gast": "11.1.2",
+				"@chevrotain/types": "11.1.2",
+				"lodash-es": "4.17.23"
 			}
-		},
-		"node_modules/@chevrotain/cst-dts-gen/node_modules/lodash-es": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-			"integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-			"license": "MIT"
 		},
 		"node_modules/@chevrotain/gast": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
-			"integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.1.2.tgz",
+			"integrity": "sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@chevrotain/types": "11.0.3",
-				"lodash-es": "4.17.21"
+				"@chevrotain/types": "11.1.2",
+				"lodash-es": "4.17.23"
 			}
 		},
-		"node_modules/@chevrotain/gast/node_modules/lodash-es": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-			"integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-			"license": "MIT"
-		},
 		"node_modules/@chevrotain/regexp-to-ast": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz",
-			"integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==",
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.1.2.tgz",
+			"integrity": "sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@chevrotain/types": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
-			"integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==",
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+			"integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@chevrotain/utils": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
-			"integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.2.tgz",
+			"integrity": "sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@colors/colors": {
@@ -2214,7 +2143,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -2237,7 +2165,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2347,7 +2274,6 @@
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
 			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -2769,7 +2695,6 @@
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
 			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -3437,9 +3362,9 @@
 			}
 		},
 		"node_modules/@docsearch/core": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.4.0.tgz",
-			"integrity": "sha512-kiwNo5KEndOnrf5Kq/e5+D9NBMCFgNsDoRpKQJ9o/xnSlheh6b8AXppMuuUVVdAUIhIfQFk/07VLjjk/fYyKmw==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.6.0.tgz",
+			"integrity": "sha512-IqG3oSd529jVRQ4dWZQKwZwQLVd//bWJTz2HiL0LkiHrI4U/vLrBasKB7lwQB/69nBAcCgs3TmudxTZSLH/ZQg==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": ">= 16.8.0 < 20.0.0",
@@ -3459,25 +3384,20 @@
 			}
 		},
 		"node_modules/@docsearch/css": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.4.0.tgz",
-			"integrity": "sha512-e9vPgtih6fkawakmYo0Y6V4BKBmDV7Ykudn7ADWXUs5b6pmtBRwDbpSG/WiaUG63G28OkJDEnsMvgIAnZgGwYw==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.6.0.tgz",
+			"integrity": "sha512-YlcAimkXclvqta47g47efzCM5CFxDwv2ClkDfEs/fC/Ak0OxPH2b3czwa4o8O1TRBf+ujFF2RiUwszz2fPVNJQ==",
 			"license": "MIT"
 		},
 		"node_modules/@docsearch/react": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.4.0.tgz",
-			"integrity": "sha512-z12zeg1mV7WD4Ag4pKSuGukETJLaucVFwszDXL/qLaEgRqxEaVacO9SR1qqnCXvZztlvz2rt7cMqryi/7sKfjA==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.6.0.tgz",
+			"integrity": "sha512-j8H5B4ArGxBPBWvw3X0J0Rm/Pjv2JDa2rV5OE0DLTp5oiBCptIJ/YlNOhZxuzbO2nwge+o3Z52nJRi3hryK9cA==",
 			"license": "MIT",
 			"dependencies": {
-				"@ai-sdk/react": "^2.0.30",
 				"@algolia/autocomplete-core": "1.19.2",
-				"@docsearch/core": "4.4.0",
-				"@docsearch/css": "4.4.0",
-				"ai": "^5.0.30",
-				"algoliasearch": "^5.28.0",
-				"marked": "^16.3.0",
-				"zod": "^4.1.8"
+				"@docsearch/core": "4.6.0",
+				"@docsearch/css": "4.6.0"
 			},
 			"peerDependencies": {
 				"@types/react": ">= 16.8.0 < 20.0.0",
@@ -3574,7 +3494,6 @@
 			"resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.9.2.tgz",
 			"integrity": "sha512-HbjwKeC+pHUFBfLMNzuSjqFE/58+rLVKmOU3lxQrpsxLBOGosYco/Q0GduBb0/jEMRiyEqjNT/01rRdOMWq5pw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@docusaurus/babel": "3.9.2",
 				"@docusaurus/bundler": "3.9.2",
@@ -3756,7 +3675,6 @@
 			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
 			"integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@docusaurus/core": "3.9.2",
 				"@docusaurus/logger": "3.9.2",
@@ -4353,9 +4271,9 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/buffers": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
-			"integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+			"version": "17.67.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-17.67.0.tgz",
+			"integrity": "sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=10.0"
@@ -4384,6 +4302,269 @@
 				"tslib": "2"
 			}
 		},
+		"node_modules/@jsonjoy.com/fs-core": {
+			"version": "4.56.10",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.56.10.tgz",
+			"integrity": "sha512-PyAEA/3cnHhsGcdY+AmIU+ZPqTuZkDhCXQ2wkXypdLitSpd6d5Ivxhnq4wa2ETRWFVJGabYynBWxIijOswSmOw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/fs-node-builtins": "4.56.10",
+				"@jsonjoy.com/fs-node-utils": "4.56.10",
+				"thingies": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-fsa": {
+			"version": "4.56.10",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.56.10.tgz",
+			"integrity": "sha512-/FVK63ysNzTPOnCCcPoPHt77TOmachdMS422txM4KhxddLdbW1fIbFMYH0AM0ow/YchCyS5gqEjKLNyv71j/5Q==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/fs-core": "4.56.10",
+				"@jsonjoy.com/fs-node-builtins": "4.56.10",
+				"@jsonjoy.com/fs-node-utils": "4.56.10",
+				"thingies": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-node": {
+			"version": "4.56.10",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.56.10.tgz",
+			"integrity": "sha512-7R4Gv3tkUdW3dXfXiOkqxkElxKNVdd8BDOWC0/dbERd0pXpPY+s2s1Mino+aTvkGrFPiY+mmVxA7zhskm4Ue4Q==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/fs-core": "4.56.10",
+				"@jsonjoy.com/fs-node-builtins": "4.56.10",
+				"@jsonjoy.com/fs-node-utils": "4.56.10",
+				"@jsonjoy.com/fs-print": "4.56.10",
+				"@jsonjoy.com/fs-snapshot": "4.56.10",
+				"glob-to-regex.js": "^1.0.0",
+				"thingies": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-node-builtins": {
+			"version": "4.56.10",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.56.10.tgz",
+			"integrity": "sha512-uUnKz8R0YJyKq5jXpZtkGV9U0pJDt8hmYcLRrPjROheIfjMXsz82kXMgAA/qNg0wrZ1Kv+hrg7azqEZx6XZCVw==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-node-to-fsa": {
+			"version": "4.56.10",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.56.10.tgz",
+			"integrity": "sha512-oH+O6Y4lhn9NyG6aEoFwIBNKZeYy66toP5LJcDOMBgL99BKQMUf/zWJspdRhMdn/3hbzQsZ8EHHsuekbFLGUWw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/fs-fsa": "4.56.10",
+				"@jsonjoy.com/fs-node-builtins": "4.56.10",
+				"@jsonjoy.com/fs-node-utils": "4.56.10"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-node-utils": {
+			"version": "4.56.10",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.56.10.tgz",
+			"integrity": "sha512-8EuPBgVI2aDPwFdaNQeNpHsyqPi3rr+85tMNG/lHvQLiVjzoZsvxA//Xd8aB567LUhy4QS03ptT+unkD/DIsNg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/fs-node-builtins": "4.56.10"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-print": {
+			"version": "4.56.10",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.56.10.tgz",
+			"integrity": "sha512-JW4fp5mAYepzFsSGrQ48ep8FXxpg4niFWHdF78wDrFGof7F3tKDJln72QFDEn/27M1yHd4v7sKHHVPh78aWcEw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/fs-node-utils": "4.56.10",
+				"tree-dump": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-snapshot": {
+			"version": "4.56.10",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.56.10.tgz",
+			"integrity": "sha512-DkR6l5fj7+qj0+fVKm/OOXMGfDFCGXLfyHkORH3DF8hxkpDgIHbhf/DwncBMs2igu/ST7OEkexn1gIqoU6Y+9g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/buffers": "^17.65.0",
+				"@jsonjoy.com/fs-node-utils": "4.56.10",
+				"@jsonjoy.com/json-pack": "^17.65.0",
+				"@jsonjoy.com/util": "^17.65.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/base64": {
+			"version": "17.67.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
+			"integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/codegen": {
+			"version": "17.67.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
+			"integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
+			"version": "17.67.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
+			"integrity": "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/base64": "17.67.0",
+				"@jsonjoy.com/buffers": "17.67.0",
+				"@jsonjoy.com/codegen": "17.67.0",
+				"@jsonjoy.com/json-pointer": "17.67.0",
+				"@jsonjoy.com/util": "17.67.0",
+				"hyperdyperid": "^1.2.0",
+				"thingies": "^2.5.0",
+				"tree-dump": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pointer": {
+			"version": "17.67.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
+			"integrity": "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/util": "17.67.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
+			"version": "17.67.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
+			"integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/buffers": "17.67.0",
+				"@jsonjoy.com/codegen": "17.67.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
 		"node_modules/@jsonjoy.com/json-pack": {
 			"version": "1.21.0",
 			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
@@ -4399,6 +4580,22 @@
 				"thingies": "^2.5.0",
 				"tree-dump": "^1.1.0"
 			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/json-pack/node_modules/@jsonjoy.com/buffers": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+			"integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=10.0"
 			},
@@ -4439,6 +4636,22 @@
 				"@jsonjoy.com/buffers": "^1.0.0",
 				"@jsonjoy.com/codegen": "^1.0.0"
 			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/util/node_modules/@jsonjoy.com/buffers": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+			"integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=10.0"
 			},
@@ -4498,7 +4711,6 @@
 			"resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
 			"integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/mdx": "^2.0.0"
 			},
@@ -4512,12 +4724,12 @@
 			}
 		},
 		"node_modules/@mermaid-js/parser": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-0.6.3.tgz",
-			"integrity": "sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.0.0.tgz",
+			"integrity": "sha512-vvK0Hi/VWndxoh03Mmz6wa1KDriSPjS2XMZL/1l19HFwygiObEEoEwSDxOqyLzzAI6J2PU3261JjTMTO7x+BPw==",
 			"license": "MIT",
 			"dependencies": {
-				"langium": "3.3.1"
+				"langium": "^4.0.0"
 			}
 		},
 		"node_modules/@noble/hashes": {
@@ -4567,22 +4779,14 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/@opentelemetry/api": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
 		"node_modules/@parcel/watcher": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.4.tgz",
-			"integrity": "sha512-WYa2tUVV5HiArWPB3ydlOc4R2ivq0IDrlqhMi3l7mVsFEXNcTfxYFPIHXHXIh/ca/y/V5N4E1zecyxdIBjYnkQ==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+			"integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"detect-libc": "^2.0.3",
 				"is-glob": "^4.0.3",
@@ -4597,25 +4801,25 @@
 				"url": "https://opencollective.com/parcel"
 			},
 			"optionalDependencies": {
-				"@parcel/watcher-android-arm64": "2.5.4",
-				"@parcel/watcher-darwin-arm64": "2.5.4",
-				"@parcel/watcher-darwin-x64": "2.5.4",
-				"@parcel/watcher-freebsd-x64": "2.5.4",
-				"@parcel/watcher-linux-arm-glibc": "2.5.4",
-				"@parcel/watcher-linux-arm-musl": "2.5.4",
-				"@parcel/watcher-linux-arm64-glibc": "2.5.4",
-				"@parcel/watcher-linux-arm64-musl": "2.5.4",
-				"@parcel/watcher-linux-x64-glibc": "2.5.4",
-				"@parcel/watcher-linux-x64-musl": "2.5.4",
-				"@parcel/watcher-win32-arm64": "2.5.4",
-				"@parcel/watcher-win32-ia32": "2.5.4",
-				"@parcel/watcher-win32-x64": "2.5.4"
+				"@parcel/watcher-android-arm64": "2.5.6",
+				"@parcel/watcher-darwin-arm64": "2.5.6",
+				"@parcel/watcher-darwin-x64": "2.5.6",
+				"@parcel/watcher-freebsd-x64": "2.5.6",
+				"@parcel/watcher-linux-arm-glibc": "2.5.6",
+				"@parcel/watcher-linux-arm-musl": "2.5.6",
+				"@parcel/watcher-linux-arm64-glibc": "2.5.6",
+				"@parcel/watcher-linux-arm64-musl": "2.5.6",
+				"@parcel/watcher-linux-x64-glibc": "2.5.6",
+				"@parcel/watcher-linux-x64-musl": "2.5.6",
+				"@parcel/watcher-win32-arm64": "2.5.6",
+				"@parcel/watcher-win32-ia32": "2.5.6",
+				"@parcel/watcher-win32-x64": "2.5.6"
 			}
 		},
 		"node_modules/@parcel/watcher-android-arm64": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.4.tgz",
-			"integrity": "sha512-hoh0vx4v+b3BNI7Cjoy2/B0ARqcwVNrzN/n7DLq9ZB4I3lrsvhrkCViJyfTj/Qi5xM9YFiH4AmHGK6pgH1ss7g==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+			"integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
 			"cpu": [
 				"arm64"
 			],
@@ -4624,6 +4828,7 @@
 			"os": [
 				"android"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -4633,9 +4838,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-darwin-arm64": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.4.tgz",
-			"integrity": "sha512-kphKy377pZiWpAOyTgQYPE5/XEKVMaj6VUjKT5VkNyUJlr2qZAn8gIc7CPzx+kbhvqHDT9d7EqdOqRXT6vk0zw==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+			"integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
 			"cpu": [
 				"arm64"
 			],
@@ -4644,6 +4849,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -4653,9 +4859,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-darwin-x64": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.4.tgz",
-			"integrity": "sha512-UKaQFhCtNJW1A9YyVz3Ju7ydf6QgrpNQfRZ35wNKUhTQ3dxJ/3MULXN5JN/0Z80V/KUBDGa3RZaKq1EQT2a2gg==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+			"integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
 			"cpu": [
 				"x64"
 			],
@@ -4664,6 +4870,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -4673,9 +4880,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-freebsd-x64": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.4.tgz",
-			"integrity": "sha512-Dib0Wv3Ow/m2/ttvLdeI2DBXloO7t3Z0oCp4bAb2aqyqOjKPPGrg10pMJJAQ7tt8P4V2rwYwywkDhUia/FgS+Q==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+			"integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
 			"cpu": [
 				"x64"
 			],
@@ -4684,6 +4891,7 @@
 			"os": [
 				"freebsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -4693,9 +4901,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-arm-glibc": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.4.tgz",
-			"integrity": "sha512-I5Vb769pdf7Q7Sf4KNy8Pogl/URRCKu9ImMmnVKYayhynuyGYMzuI4UOWnegQNa2sGpsPSbzDsqbHNMyeyPCgw==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+			"integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
 			"cpu": [
 				"arm"
 			],
@@ -4704,6 +4912,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -4713,9 +4922,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-arm-musl": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.4.tgz",
-			"integrity": "sha512-kGO8RPvVrcAotV4QcWh8kZuHr9bXi9a3bSZw7kFarYR0+fGliU7hd/zevhjw8fnvIKG3J9EO5G6sXNGCSNMYPQ==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+			"integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
 			"cpu": [
 				"arm"
 			],
@@ -4724,6 +4933,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -4733,9 +4943,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-arm64-glibc": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.4.tgz",
-			"integrity": "sha512-KU75aooXhqGFY2W5/p8DYYHt4hrjHZod8AhcGAmhzPn/etTa+lYCDB2b1sJy3sWJ8ahFVTdy+EbqSBvMx3iFlw==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+			"integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
 			"cpu": [
 				"arm64"
 			],
@@ -4744,6 +4954,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -4753,9 +4964,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-arm64-musl": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.4.tgz",
-			"integrity": "sha512-Qx8uNiIekVutnzbVdrgSanM+cbpDD3boB1f8vMtnuG5Zau4/bdDbXyKwIn0ToqFhIuob73bcxV9NwRm04/hzHQ==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+			"integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
 			"cpu": [
 				"arm64"
 			],
@@ -4764,6 +4975,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -4773,9 +4985,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-x64-glibc": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.4.tgz",
-			"integrity": "sha512-UYBQvhYmgAv61LNUn24qGQdjtycFBKSK3EXr72DbJqX9aaLbtCOO8+1SkKhD/GNiJ97ExgcHBrukcYhVjrnogA==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+			"integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
 			"cpu": [
 				"x64"
 			],
@@ -4784,6 +4996,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -4793,9 +5006,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-x64-musl": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.4.tgz",
-			"integrity": "sha512-YoRWCVgxv8akZrMhdyVi6/TyoeeMkQ0PGGOf2E4omODrvd1wxniXP+DBynKoHryStks7l+fDAMUBRzqNHrVOpg==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+			"integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
 			"cpu": [
 				"x64"
 			],
@@ -4804,6 +5017,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -4813,9 +5027,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-win32-arm64": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.4.tgz",
-			"integrity": "sha512-iby+D/YNXWkiQNYcIhg8P5hSjzXEHaQrk2SLrWOUD7VeC4Ohu0WQvmV+HDJokZVJ2UjJ4AGXW3bx7Lls9Ln4TQ==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+			"integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -4824,6 +5038,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -4833,9 +5048,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-win32-ia32": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.4.tgz",
-			"integrity": "sha512-vQN+KIReG0a2ZDpVv8cgddlf67J8hk1WfZMMP7sMeZmJRSmEax5xNDNWKdgqSe2brOKTQQAs3aCCUal2qBHAyg==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+			"integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
 			"cpu": [
 				"ia32"
 			],
@@ -4844,6 +5059,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -4853,9 +5069,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-win32-x64": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.4.tgz",
-			"integrity": "sha512-3A6efb6BOKwyw7yk9ro2vus2YTt2nvcd56AuzxdMiVOxL9umDyN5PKkKfZ/gZ9row41SjVmTVQNWQhaRRGpOKw==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+			"integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
 			"cpu": [
 				"x64"
 			],
@@ -4864,6 +5080,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -4878,6 +5095,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -4886,92 +5104,92 @@
 			}
 		},
 		"node_modules/@peculiar/asn1-cms": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.0.tgz",
-			"integrity": "sha512-2uZqP+ggSncESeUF/9Su8rWqGclEfEiz1SyU02WX5fUONFfkjzS2Z/F1Li0ofSmf4JqYXIOdCAZqIXAIBAT1OA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.1.tgz",
+			"integrity": "sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==",
 			"license": "MIT",
 			"dependencies": {
 				"@peculiar/asn1-schema": "^2.6.0",
-				"@peculiar/asn1-x509": "^2.6.0",
-				"@peculiar/asn1-x509-attr": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.1",
+				"@peculiar/asn1-x509-attr": "^2.6.1",
 				"asn1js": "^3.0.6",
 				"tslib": "^2.8.1"
 			}
 		},
 		"node_modules/@peculiar/asn1-csr": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.6.0.tgz",
-			"integrity": "sha512-BeWIu5VpTIhfRysfEp73SGbwjjoLL/JWXhJ/9mo4vXnz3tRGm+NGm3KNcRzQ9VMVqwYS2RHlolz21svzRXIHPQ==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.6.1.tgz",
+			"integrity": "sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w==",
 			"license": "MIT",
 			"dependencies": {
 				"@peculiar/asn1-schema": "^2.6.0",
-				"@peculiar/asn1-x509": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.1",
 				"asn1js": "^3.0.6",
 				"tslib": "^2.8.1"
 			}
 		},
 		"node_modules/@peculiar/asn1-ecc": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.6.0.tgz",
-			"integrity": "sha512-FF3LMGq6SfAOwUG2sKpPXblibn6XnEIKa+SryvUl5Pik+WR9rmRA3OCiwz8R3lVXnYnyRkSZsSLdml8H3UiOcw==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.6.1.tgz",
+			"integrity": "sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g==",
 			"license": "MIT",
 			"dependencies": {
 				"@peculiar/asn1-schema": "^2.6.0",
-				"@peculiar/asn1-x509": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.1",
 				"asn1js": "^3.0.6",
 				"tslib": "^2.8.1"
 			}
 		},
 		"node_modules/@peculiar/asn1-pfx": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.6.0.tgz",
-			"integrity": "sha512-rtUvtf+tyKGgokHHmZzeUojRZJYPxoD/jaN1+VAB4kKR7tXrnDCA/RAWXAIhMJJC+7W27IIRGe9djvxKgsldCQ==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.6.1.tgz",
+			"integrity": "sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw==",
 			"license": "MIT",
 			"dependencies": {
-				"@peculiar/asn1-cms": "^2.6.0",
-				"@peculiar/asn1-pkcs8": "^2.6.0",
-				"@peculiar/asn1-rsa": "^2.6.0",
+				"@peculiar/asn1-cms": "^2.6.1",
+				"@peculiar/asn1-pkcs8": "^2.6.1",
+				"@peculiar/asn1-rsa": "^2.6.1",
 				"@peculiar/asn1-schema": "^2.6.0",
 				"asn1js": "^3.0.6",
 				"tslib": "^2.8.1"
 			}
 		},
 		"node_modules/@peculiar/asn1-pkcs8": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.6.0.tgz",
-			"integrity": "sha512-KyQ4D8G/NrS7Fw3XCJrngxmjwO/3htnA0lL9gDICvEQ+GJ+EPFqldcJQTwPIdvx98Tua+WjkdKHSC0/Km7T+lA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.6.1.tgz",
+			"integrity": "sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw==",
 			"license": "MIT",
 			"dependencies": {
 				"@peculiar/asn1-schema": "^2.6.0",
-				"@peculiar/asn1-x509": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.1",
 				"asn1js": "^3.0.6",
 				"tslib": "^2.8.1"
 			}
 		},
 		"node_modules/@peculiar/asn1-pkcs9": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.6.0.tgz",
-			"integrity": "sha512-b78OQ6OciW0aqZxdzliXGYHASeCvvw5caqidbpQRYW2mBtXIX2WhofNXTEe7NyxTb0P6J62kAAWLwn0HuMF1Fw==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.6.1.tgz",
+			"integrity": "sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw==",
 			"license": "MIT",
 			"dependencies": {
-				"@peculiar/asn1-cms": "^2.6.0",
-				"@peculiar/asn1-pfx": "^2.6.0",
-				"@peculiar/asn1-pkcs8": "^2.6.0",
+				"@peculiar/asn1-cms": "^2.6.1",
+				"@peculiar/asn1-pfx": "^2.6.1",
+				"@peculiar/asn1-pkcs8": "^2.6.1",
 				"@peculiar/asn1-schema": "^2.6.0",
-				"@peculiar/asn1-x509": "^2.6.0",
-				"@peculiar/asn1-x509-attr": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.1",
+				"@peculiar/asn1-x509-attr": "^2.6.1",
 				"asn1js": "^3.0.6",
 				"tslib": "^2.8.1"
 			}
 		},
 		"node_modules/@peculiar/asn1-rsa": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.6.0.tgz",
-			"integrity": "sha512-Nu4C19tsrTsCp9fDrH+sdcOKoVfdfoQQ7S3VqjJU6vedR7tY3RLkQ5oguOIB3zFW33USDUuYZnPEQYySlgha4w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.6.1.tgz",
+			"integrity": "sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA==",
 			"license": "MIT",
 			"dependencies": {
 				"@peculiar/asn1-schema": "^2.6.0",
-				"@peculiar/asn1-x509": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.1",
 				"asn1js": "^3.0.6",
 				"tslib": "^2.8.1"
 			}
@@ -4988,9 +5206,9 @@
 			}
 		},
 		"node_modules/@peculiar/asn1-x509": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.0.tgz",
-			"integrity": "sha512-uzYbPEpoQiBoTq0/+jZtpM6Gq6zADBx+JNFP3yqRgziWBxQ/Dt/HcuvRfm9zJTPdRcBqPNdaRHTVwpyiq6iNMA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.1.tgz",
+			"integrity": "sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==",
 			"license": "MIT",
 			"dependencies": {
 				"@peculiar/asn1-schema": "^2.6.0",
@@ -5000,13 +5218,13 @@
 			}
 		},
 		"node_modules/@peculiar/asn1-x509-attr": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.0.tgz",
-			"integrity": "sha512-MuIAXFX3/dc8gmoZBkwJWxUWOSvG4MMDntXhrOZpJVMkYX+MYc/rUAU2uJOved9iJEoiUx7//3D8oG83a78UJA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.1.tgz",
+			"integrity": "sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@peculiar/asn1-schema": "^2.6.0",
-				"@peculiar/asn1-x509": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.1",
 				"asn1js": "^3.0.6",
 				"tslib": "^2.8.1"
 			}
@@ -5061,9 +5279,9 @@
 			"license": "ISC"
 		},
 		"node_modules/@pnpm/npm-conf": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.3.1.tgz",
-			"integrity": "sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.2.tgz",
+			"integrity": "sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==",
 			"license": "MIT",
 			"dependencies": {
 				"@pnpm/config.env-replace": "^1.1.0",
@@ -5102,9 +5320,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@sinclair/typebox": {
-			"version": "0.27.8",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+			"integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
 			"license": "MIT"
 		},
 		"node_modules/@sindresorhus/is": {
@@ -5129,12 +5347,6 @@
 				"micromark-util-character": "^1.1.0",
 				"micromark-util-symbol": "^1.0.1"
 			}
-		},
-		"node_modules/@standard-schema/spec": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-			"license": "MIT"
 		},
 		"node_modules/@svgr/babel-plugin-add-jsx-attribute": {
 			"version": "8.0.0",
@@ -5295,7 +5507,6 @@
 			"resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
 			"integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.21.3",
 				"@svgr/babel-preset": "8.1.0",
@@ -5808,9 +6019,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/http-cache-semantics": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-			"integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+			"integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
 			"license": "MIT"
 		},
 		"node_modules/@types/http-errors": {
@@ -5886,18 +6097,18 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.0.8",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.8.tgz",
-			"integrity": "sha512-powIePYMmC3ibL0UJ2i2s0WIbq6cg6UyVFQxSCpaPxxzAaziRfimGivjdF943sSGV6RADVbk0Nvlm5P/FB44Zg==",
+			"version": "25.3.3",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
+			"integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.16.0"
+				"undici-types": "~7.18.0"
 			}
 		},
 		"node_modules/@types/prismjs": {
-			"version": "1.26.5",
-			"resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.5.tgz",
-			"integrity": "sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==",
+			"version": "1.26.6",
+			"resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.6.tgz",
+			"integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==",
 			"license": "MIT"
 		},
 		"node_modules/@types/qs": {
@@ -5913,11 +6124,10 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/react": {
-			"version": "19.2.8",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
-			"integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
+			"version": "19.2.14",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+			"integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"csstype": "^3.2.2"
 			}
@@ -6059,15 +6269,6 @@
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
 			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
 			"license": "ISC"
-		},
-		"node_modules/@vercel/oidc": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
-			"integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">= 20"
-			}
 		},
 		"node_modules/@webassemblyjs/ast": {
 			"version": "1.14.1",
@@ -6271,11 +6472,10 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -6305,9 +6505,9 @@
 			}
 		},
 		"node_modules/acorn-walk": {
-			"version": "8.3.4",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-			"integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+			"version": "8.3.5",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+			"integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
 			"license": "MIT",
 			"dependencies": {
 				"acorn": "^8.11.0"
@@ -6338,30 +6538,11 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/ai": {
-			"version": "5.0.121",
-			"resolved": "https://registry.npmjs.org/ai/-/ai-5.0.121.tgz",
-			"integrity": "sha512-3iYPdARKGLryC/7OA9RgBUaym1gynvWS7UPy8NwoRNCKP52lshldtHB5xcEfVviw7liWH2zJlW9yEzsDglcIEQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@ai-sdk/gateway": "2.0.27",
-				"@ai-sdk/provider": "2.0.1",
-				"@ai-sdk/provider-utils": "3.0.20",
-				"@opentelemetry/api": "1.9.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"zod": "^3.25.76 || ^4.1.8"
-			}
-		},
 		"node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -6403,35 +6584,34 @@
 			}
 		},
 		"node_modules/algoliasearch": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.46.3.tgz",
-			"integrity": "sha512-n/NdPglzmkcNYZfIT3Fo8pnDR/lKiK1kZ1Yaa315UoLyHymADhWw15+bzN5gBxrCA8KyeNu0JJD6mLtTov43lQ==",
+			"version": "5.49.1",
+			"resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.49.1.tgz",
+			"integrity": "sha512-X3Pp2aRQhg4xUC6PQtkubn5NpRKuUPQ9FPDQlx36SmpFwwH2N0/tw4c+NXV3nw3PsgeUs+BuWGP0gjz3TvENLQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@algolia/abtesting": "1.12.3",
-				"@algolia/client-abtesting": "5.46.3",
-				"@algolia/client-analytics": "5.46.3",
-				"@algolia/client-common": "5.46.3",
-				"@algolia/client-insights": "5.46.3",
-				"@algolia/client-personalization": "5.46.3",
-				"@algolia/client-query-suggestions": "5.46.3",
-				"@algolia/client-search": "5.46.3",
-				"@algolia/ingestion": "1.46.3",
-				"@algolia/monitoring": "1.46.3",
-				"@algolia/recommend": "5.46.3",
-				"@algolia/requester-browser-xhr": "5.46.3",
-				"@algolia/requester-fetch": "5.46.3",
-				"@algolia/requester-node-http": "5.46.3"
+				"@algolia/abtesting": "1.15.1",
+				"@algolia/client-abtesting": "5.49.1",
+				"@algolia/client-analytics": "5.49.1",
+				"@algolia/client-common": "5.49.1",
+				"@algolia/client-insights": "5.49.1",
+				"@algolia/client-personalization": "5.49.1",
+				"@algolia/client-query-suggestions": "5.49.1",
+				"@algolia/client-search": "5.49.1",
+				"@algolia/ingestion": "1.49.1",
+				"@algolia/monitoring": "1.49.1",
+				"@algolia/recommend": "5.49.1",
+				"@algolia/requester-browser-xhr": "5.49.1",
+				"@algolia/requester-fetch": "5.49.1",
+				"@algolia/requester-node-http": "5.49.1"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/algoliasearch-helper": {
-			"version": "3.27.0",
-			"resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.27.0.tgz",
-			"integrity": "sha512-eNYchRerbsvk2doHOMfdS1/B6Tm70oGtu8mzQlrNzbCeQ8p1MjCW8t/BL6iZ5PD+cL5NNMgTMyMnmiXZ1sgmNw==",
+			"version": "3.28.0",
+			"resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.28.0.tgz",
+			"integrity": "sha512-GBN0xsxGggaCPElZq24QzMdfphrjIiV2xA+hRXE4/UMpN3nsF2WrM8q+x80OGvGpJWtB7F+4Hq5eSfWwuejXrg==",
 			"license": "MIT",
 			"dependencies": {
 				"@algolia/events": "^4.0.1"
@@ -6596,9 +6776,9 @@
 			}
 		},
 		"node_modules/autoprefixer": {
-			"version": "10.4.23",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.23.tgz",
-			"integrity": "sha512-YYTXSFulfwytnjAPlw8QHncHJmlvFKtczb8InXaAx9Q0LbfDnfEYDE55omerIJKihhmU61Ft+cAOSzQVaBUmeA==",
+			"version": "10.4.27",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
+			"integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -6616,7 +6796,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.28.1",
-				"caniuse-lite": "^1.0.30001760",
+				"caniuse-lite": "^1.0.30001774",
 				"fraction.js": "^5.3.4",
 				"picocolors": "^1.1.1",
 				"postcss-value-parser": "^4.2.0"
@@ -6658,13 +6838,13 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
-			"version": "0.4.14",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
-			"integrity": "sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==",
+			"version": "0.4.15",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.15.tgz",
+			"integrity": "sha512-hR3GwrRwHUfYwGfrisXPIDP3JcYfBrW7wKE7+Au6wDYl7fm/ka1NEII6kORzxNU556JjfidZeBsO10kYvtV1aw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.27.7",
-				"@babel/helper-define-polyfill-provider": "^0.6.5",
+				"@babel/compat-data": "^7.28.6",
+				"@babel/helper-define-polyfill-provider": "^0.6.6",
 				"semver": "^6.3.1"
 			},
 			"peerDependencies": {
@@ -6694,12 +6874,12 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-regenerator": {
-			"version": "0.6.5",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.5.tgz",
-			"integrity": "sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==",
+			"version": "0.6.6",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.6.tgz",
+			"integrity": "sha512-hYm+XLYRMvupxiQzrvXUj7YyvFFVfv5gI0R71AJzudg1g2AI2vyCPPIFEBjk162/wFzti3inBHo7isWFuEVS/A==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.6.5"
+				"@babel/helper-define-polyfill-provider": "^0.6.6"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -6722,12 +6902,15 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.9.14",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.14.tgz",
-			"integrity": "sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==",
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
+			"integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
 			"license": "Apache-2.0",
 			"bin": {
-				"baseline-browser-mapping": "dist/cli.js"
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/batch": {
@@ -6896,7 +7079,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -7068,9 +7250,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001764",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001764.tgz",
-			"integrity": "sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==",
+			"version": "1.0.30001775",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001775.tgz",
+			"integrity": "sha512-s3Qv7Lht9zbVKE9XoTyRG6wVDCKdtOFIjBGg3+Yhn6JaytuNKPIjBMTMIY1AnOH3seL5mvF+x33oGAyK3hVt3A==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -7201,17 +7383,17 @@
 			}
 		},
 		"node_modules/chevrotain": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
-			"integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
+			"integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@chevrotain/cst-dts-gen": "11.0.3",
-				"@chevrotain/gast": "11.0.3",
-				"@chevrotain/regexp-to-ast": "11.0.3",
-				"@chevrotain/types": "11.0.3",
-				"@chevrotain/utils": "11.0.3",
-				"lodash-es": "4.17.21"
+				"@chevrotain/cst-dts-gen": "11.1.2",
+				"@chevrotain/gast": "11.1.2",
+				"@chevrotain/regexp-to-ast": "11.1.2",
+				"@chevrotain/types": "11.1.2",
+				"@chevrotain/utils": "11.1.2",
+				"lodash-es": "4.17.23"
 			}
 		},
 		"node_modules/chevrotain-allstar": {
@@ -7225,12 +7407,6 @@
 			"peerDependencies": {
 				"chevrotain": "^11.0.0"
 			}
-		},
-		"node_modules/chevrotain/node_modules/lodash-es": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-			"integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-			"license": "MIT"
 		},
 		"node_modules/chokidar": {
 			"version": "3.6.0",
@@ -7695,9 +7871,9 @@
 			}
 		},
 		"node_modules/core-js": {
-			"version": "3.47.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.47.0.tgz",
-			"integrity": "sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==",
+			"version": "3.48.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
+			"integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"funding": {
@@ -7706,12 +7882,12 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.47.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.47.0.tgz",
-			"integrity": "sha512-IGfuznZ/n7Kp9+nypamBhvwdwLsW6KC8IOaURw2doAK5e98AG3acVLdh0woOnEqCfUtS+Vu882JE4k/DAm3ItQ==",
+			"version": "3.48.0",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.48.0.tgz",
+			"integrity": "sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==",
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.28.0"
+				"browserslist": "^4.28.1"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -7719,9 +7895,9 @@
 			}
 		},
 		"node_modules/core-js-pure": {
-			"version": "3.47.0",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.47.0.tgz",
-			"integrity": "sha512-BcxeDbzUrRnXGYIVAGFtcGQVNpFcUhVjr6W7F8XktvQW2iJP9e66GP6xdKotCRFlrxBvNIBrhwKteRXqMV86Nw==",
+			"version": "3.48.0",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.48.0.tgz",
+			"integrity": "sha512-1slJgk89tWC51HQ1AEqG+s2VuwpTRr8ocu4n20QUcH1v9lAN0RXen0Q0AABa/DK1I7RrNWLucplOHMx8hfTGTw==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"funding": {
@@ -7915,7 +8091,6 @@
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
 			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -8067,9 +8242,9 @@
 			}
 		},
 		"node_modules/cssdb": {
-			"version": "8.7.0",
-			"resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.7.0.tgz",
-			"integrity": "sha512-UxiWVpV953ENHqAKjKRPZHNDfRo3uOymvO5Ef7MFCWlenaohkYj7PTO7WCBdjZm8z/aDZd6rXyUIlwZ0AjyFSg==",
+			"version": "8.8.0",
+			"resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.8.0.tgz",
+			"integrity": "sha512-QbLeyz2Bgso1iRlh7IpWk6OKa3lLNGXsujVjDMPl9rOZpxKeiG69icLpbLCFxeURwmcdIfZqQyhlooKJYM4f8Q==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -8235,7 +8410,6 @@
 			"resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
 			"integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10"
 			}
@@ -8645,7 +8819,6 @@
 			"resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
 			"integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
 			"license": "ISC",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -8770,9 +8943,9 @@
 			}
 		},
 		"node_modules/decode-named-character-reference": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
-			"integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+			"integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
 			"license": "MIT",
 			"dependencies": {
 				"character-entities": "^2.0.0"
@@ -8828,9 +9001,9 @@
 			}
 		},
 		"node_modules/default-browser": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.4.0.tgz",
-			"integrity": "sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+			"integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
 			"license": "MIT",
 			"dependencies": {
 				"bundle-name": "^4.1.0",
@@ -8950,6 +9123,7 @@
 			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -9167,9 +9341,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.267",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
-			"integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
+			"version": "1.5.302",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
+			"integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
 			"license": "ISC"
 		},
 		"node_modules/emoji-regex": {
@@ -9213,13 +9387,13 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.18.4",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
-			"integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
+			"version": "5.20.0",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
+			"integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
 			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
-				"tapable": "^2.2.0"
+				"tapable": "^2.3.0"
 			},
 			"engines": {
 				"node": ">=10.13.0"
@@ -9569,15 +9743,6 @@
 				"node": ">=0.8.x"
 			}
 		},
-		"node_modules/eventsource-parser": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-			"integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
 		"node_modules/execa": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -9842,11 +10007,10 @@
 			}
 		},
 		"node_modules/file-loader/node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -10640,19 +10804,25 @@
 			}
 		},
 		"node_modules/html-dom-parser": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.1.2.tgz",
-			"integrity": "sha512-9nD3Rj3/FuQt83AgIa1Y3ruzspwFFA54AJbQnohXN+K6fL1/bhcDQJJY5Ne4L4A163ADQFVESd/0TLyNoV0mfg==",
+			"version": "5.1.8",
+			"resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.1.8.tgz",
+			"integrity": "sha512-MCIUng//mF2qTtGHXJWr6OLfHWmg3Pm8ezpfiltF83tizPWY17JxT4dRLE8lykJ5bChJELoY3onQKPbufJHxYA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/remarkablemark"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"domhandler": "5.0.3",
-				"htmlparser2": "10.0.0"
+				"htmlparser2": "10.1.0"
 			}
 		},
 		"node_modules/html-dom-parser/node_modules/entities": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+			"integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.12"
@@ -10662,9 +10832,9 @@
 			}
 		},
 		"node_modules/html-dom-parser/node_modules/htmlparser2": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
-			"integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+			"integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
 			"funding": [
 				"https://github.com/fb55/htmlparser2?sponsor=1",
 				{
@@ -10676,8 +10846,8 @@
 			"dependencies": {
 				"domelementtype": "^2.3.0",
 				"domhandler": "^5.0.3",
-				"domutils": "^3.2.1",
-				"entities": "^6.0.0"
+				"domutils": "^3.2.2",
+				"entities": "^7.0.1"
 			}
 		},
 		"node_modules/html-escaper": {
@@ -10717,13 +10887,23 @@
 			}
 		},
 		"node_modules/html-react-parser": {
-			"version": "5.2.11",
-			"resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.11.tgz",
-			"integrity": "sha512-WnSQVn/D1UTj64nSz5y8MriL+MrbsZH80Ytr1oqKqs8DGZnphWY1R1pl3t7TY3rpqTSu+FHA21P80lrsmrdNBA==",
+			"version": "5.2.17",
+			"resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.17.tgz",
+			"integrity": "sha512-m+K/7Moq1jodAB4VL0RXSOmtwLUYoAsikZhwd+hGQe5Vtw2dbWfpFd60poxojMU0Tsh9w59mN1QLEcoHz0Dx9w==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/remarkablemark"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/html-react-parser"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"domhandler": "5.0.3",
-				"html-dom-parser": "5.1.2",
+				"html-dom-parser": "5.1.8",
 				"react-property": "2.0.2",
 				"style-to-js": "1.1.21"
 			},
@@ -10760,9 +10940,9 @@
 			}
 		},
 		"node_modules/html-webpack-plugin": {
-			"version": "5.6.5",
-			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.5.tgz",
-			"integrity": "sha512-4xynFbKNNk+WlzXeQQ+6YYsH2g7mpfPszQZUi3ovKlj+pDmngQ7vRXjrrmGROabmKwyQkcgcX5hqfOwHbFmK5g==",
+			"version": "5.6.6",
+			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.6.tgz",
+			"integrity": "sha512-bLjW01UTrvoWTJQL5LsMRo1SypHW80FTm12OJRSnr3v6YHNhfe+1r0MYUZJMACxnCHURVnBWRwAsWs2yPU9Ezw==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/html-minifier-terser": "^6.0.0",
@@ -11008,7 +11188,8 @@
 			"version": "5.1.4",
 			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
 			"integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/import-fresh": {
 			"version": "3.3.1",
@@ -11303,9 +11484,9 @@
 			}
 		},
 		"node_modules/is-network-error": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.0.tgz",
-			"integrity": "sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
+			"integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=16"
@@ -11557,12 +11738,6 @@
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"license": "MIT"
 		},
-		"node_modules/json-schema": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-			"license": "(AFL-2.1 OR BSD-3-Clause)"
-		},
 		"node_modules/json-schema-traverse": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -11600,9 +11775,9 @@
 			"license": "MIT"
 		},
 		"node_modules/katex": {
-			"version": "0.16.27",
-			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.27.tgz",
-			"integrity": "sha512-aeQoDkuRWSqQN6nSvVCEFvfXdqo1OQiCmmW1kc9xSdjutPv7BGO7pqY9sQRJpMOGrEdfDgF2TfRXe5eUAD2Waw==",
+			"version": "0.16.33",
+			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.33.tgz",
+			"integrity": "sha512-q3N5u+1sY9Bu7T4nlXoiRBXWfwSefNGoKeOwekV+gw0cAXQlz2Ww6BLcmBxVDeXBMUDQv6fK5bcNaJLxob3ZQA==",
 			"funding": [
 				"https://opencollective.com/katex",
 				"https://github.com/sponsors/katex"
@@ -11657,19 +11832,20 @@
 			}
 		},
 		"node_modules/langium": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/langium/-/langium-3.3.1.tgz",
-			"integrity": "sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/langium/-/langium-4.2.1.tgz",
+			"integrity": "sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==",
 			"license": "MIT",
 			"dependencies": {
-				"chevrotain": "~11.0.3",
-				"chevrotain-allstar": "~0.3.0",
+				"chevrotain": "~11.1.1",
+				"chevrotain-allstar": "~0.3.1",
 				"vscode-languageserver": "~9.0.1",
 				"vscode-languageserver-textdocument": "~1.0.11",
-				"vscode-uri": "~3.0.8"
+				"vscode-uri": "~3.1.0"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
 			}
 		},
 		"node_modules/latest-version": {
@@ -11688,9 +11864,9 @@
 			}
 		},
 		"node_modules/launch-editor": {
-			"version": "2.12.0",
-			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.12.0.tgz",
-			"integrity": "sha512-giOHXoOtifjdHqUamwKq6c49GzBdLjvxrd2D+Q4V6uOHopJv7p9VJxikDsQ/CBXZbEITgUqSVHXLTG3VhPP1Dg==",
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.13.1.tgz",
+			"integrity": "sha512-lPSddlAAluRKJ7/cjRFoXUFzaX7q/YKI7yPHuEvSJVqoXvFnJov1/Ud87Aa4zULIbA9Nja4mSPK8l0z/7eV2wA==",
 			"license": "MIT",
 			"dependencies": {
 				"picocolors": "^1.1.1",
@@ -11773,15 +11949,15 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
 			"license": "MIT"
 		},
 		"node_modules/lodash-es": {
-			"version": "4.17.22",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.22.tgz",
-			"integrity": "sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==",
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+			"integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.debounce": {
@@ -11947,9 +12123,9 @@
 			}
 		},
 		"node_modules/mdast-util-from-markdown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
-			"integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+			"integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mdast": "^4.0.0",
@@ -12315,11 +12491,19 @@
 			}
 		},
 		"node_modules/memfs": {
-			"version": "4.52.0",
-			"resolved": "https://registry.npmjs.org/memfs/-/memfs-4.52.0.tgz",
-			"integrity": "sha512-dG5ZY1wUCPWhtl4M2mlc7Wx4OrMGtiI79axnScxwDoPR/25biQYrYm21OpKyZcnKv8pvWaX95SRtZgecZ84gFg==",
+			"version": "4.56.10",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-4.56.10.tgz",
+			"integrity": "sha512-eLvzyrwqLHnLYalJP7YZ3wBe79MXktMdfQbvMrVD80K+NhrIukCVBvgP30zTJYEEDh9hZ/ep9z0KOdD7FSHo7w==",
 			"license": "Apache-2.0",
 			"dependencies": {
+				"@jsonjoy.com/fs-core": "4.56.10",
+				"@jsonjoy.com/fs-fsa": "4.56.10",
+				"@jsonjoy.com/fs-node": "4.56.10",
+				"@jsonjoy.com/fs-node-builtins": "4.56.10",
+				"@jsonjoy.com/fs-node-to-fsa": "4.56.10",
+				"@jsonjoy.com/fs-node-utils": "4.56.10",
+				"@jsonjoy.com/fs-print": "4.56.10",
+				"@jsonjoy.com/fs-snapshot": "4.56.10",
 				"@jsonjoy.com/json-pack": "^1.11.0",
 				"@jsonjoy.com/util": "^1.9.0",
 				"glob-to-regex.js": "^1.0.1",
@@ -12330,6 +12514,9 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
 			}
 		},
 		"node_modules/merge-descriptors": {
@@ -12357,14 +12544,14 @@
 			}
 		},
 		"node_modules/mermaid": {
-			"version": "11.12.2",
-			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.12.2.tgz",
-			"integrity": "sha512-n34QPDPEKmaeCG4WDMGy0OT6PSyxKCfy2pJgShP+Qow2KLrvWjclwbc3yXfSIf4BanqWEhQEpngWwNp/XhZt6w==",
+			"version": "11.12.3",
+			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.12.3.tgz",
+			"integrity": "sha512-wN5ZSgJQIC+CHJut9xaKWsknLxaFBwCPwPkGTSUYrTiHORWvpT8RxGk849HPnpUAQ+/9BPRqYb80jTpearrHzQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@braintree/sanitize-url": "^7.1.1",
 				"@iconify/utils": "^3.0.1",
-				"@mermaid-js/parser": "^0.6.3",
+				"@mermaid-js/parser": "^1.0.0",
 				"@types/d3": "^7.4.3",
 				"cytoscape": "^3.29.3",
 				"cytoscape-cose-bilkent": "^4.1.0",
@@ -12376,7 +12563,7 @@
 				"dompurify": "^3.2.5",
 				"katex": "^0.16.22",
 				"khroma": "^2.1.0",
-				"lodash-es": "^4.17.21",
+				"lodash-es": "^4.17.23",
 				"marked": "^16.2.1",
 				"roughjs": "^4.6.6",
 				"stylis": "^4.3.6",
@@ -14245,9 +14432,9 @@
 			}
 		},
 		"node_modules/mini-css-extract-plugin": {
-			"version": "2.9.4",
-			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.4.tgz",
-			"integrity": "sha512-ZWYT7ln73Hptxqxk2DxPU9MmapXRhxkJD6tkSR04dnQxm8BGu2hzgKLugK5yySD97u/8yy7Ma7E76k9ZdvtjkQ==",
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.10.0.tgz",
+			"integrity": "sha512-540P2c5dYnJlyJxTaSloliZexv8rji6rY8FhQN+WF/82iHQfA23j/xtJx97L+mXOML27EqksSek/g4eK7jaL3g==",
 			"license": "MIT",
 			"dependencies": {
 				"schema-utils": "^4.0.0",
@@ -14379,7 +14566,8 @@
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
 			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/node-emoji": {
 			"version": "2.2.0",
@@ -14474,11 +14662,10 @@
 			}
 		},
 		"node_modules/null-loader/node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -15038,9 +15225,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.6",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+			"version": "8.5.8",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -15056,7 +15243,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -15960,7 +16146,6 @@
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
 			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -16654,9 +16839,9 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.14.1",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-			"integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+			"version": "6.14.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"side-channel": "^1.1.0"
@@ -16785,26 +16970,24 @@
 			}
 		},
 		"node_modules/react": {
-			"version": "19.2.3",
-			"resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
-			"integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
+			"version": "19.2.4",
+			"resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+			"integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/react-dom": {
-			"version": "19.2.3",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
-			"integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
+			"version": "19.2.4",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+			"integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
 			"peerDependencies": {
-				"react": "^19.2.3"
+				"react": "^19.2.4"
 			}
 		},
 		"node_modules/react-fast-compare": {
@@ -16855,7 +17038,6 @@
 			"resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
 			"integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/react": "*"
 			},
@@ -16890,7 +17072,6 @@
 			"resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
 			"integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.12.13",
 				"history": "^4.9.0",
@@ -17088,12 +17269,12 @@
 			}
 		},
 		"node_modules/registry-auth-token": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.0.tgz",
-			"integrity": "sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.1.tgz",
+			"integrity": "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@pnpm/npm-conf": "^2.1.0"
+				"@pnpm/npm-conf": "^3.0.2"
 			},
 			"engines": {
 				"node": ">=14"
@@ -17610,10 +17791,11 @@
 			"license": "MIT"
 		},
 		"node_modules/sass": {
-			"version": "1.97.2",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
-			"integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
+			"version": "1.97.3",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
+			"integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"chokidar": "^4.0.0",
 				"immutable": "^5.0.2",
@@ -17630,9 +17812,9 @@
 			}
 		},
 		"node_modules/sass-loader": {
-			"version": "16.0.6",
-			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.6.tgz",
-			"integrity": "sha512-sglGzId5gmlfxNs4gK2U3h7HlVRfx278YK6Ono5lwzuvi1jxig80YiuHkaDBVsYIKFhx8wN7XSCI0M2IDS/3qA==",
+			"version": "16.0.7",
+			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.7.tgz",
+			"integrity": "sha512-w6q+fRHourZ+e+xA1kcsF27iGM6jdB8teexYCfdUw0sYgcDNeZESnDNT9sUmmPm3ooziwUJXGwZJSTF3kOdBfA==",
 			"license": "MIT",
 			"dependencies": {
 				"neo-async": "^2.6.2"
@@ -17645,7 +17827,7 @@
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"@rspack/core": "0.x || 1.x",
+				"@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
 				"node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
 				"sass": "^1.3.0",
 				"sass-embedded": "*",
@@ -17674,6 +17856,7 @@
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
 			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"readdirp": "^4.0.1"
 			},
@@ -17689,6 +17872,7 @@
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
 			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 14.18.0"
 			},
@@ -17698,9 +17882,9 @@
 			}
 		},
 		"node_modules/sax": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
-			"integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
+			"integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=11.0.0"
@@ -17777,9 +17961,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -17882,21 +18066,25 @@
 			"license": "MIT"
 		},
 		"node_modules/serve-index": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
-			"integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.2.tgz",
+			"integrity": "sha512-KDj11HScOaLmrPxl70KYNW1PksP4Nb/CLL2yvC+Qd2kHMPEEpfc4Re2e4FOay+bC/+XQl/7zAcWON3JVo5v3KQ==",
 			"license": "MIT",
 			"dependencies": {
-				"accepts": "~1.3.4",
+				"accepts": "~1.3.8",
 				"batch": "0.6.1",
 				"debug": "2.6.9",
 				"escape-html": "~1.0.3",
-				"http-errors": "~1.6.2",
-				"mime-types": "~2.1.17",
-				"parseurl": "~1.3.2"
+				"http-errors": "~1.8.0",
+				"mime-types": "~2.1.35",
+				"parseurl": "~1.3.3"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/serve-index/node_modules/debug": {
@@ -17918,37 +18106,47 @@
 			}
 		},
 		"node_modules/serve-index/node_modules/http-errors": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-			"integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+			"integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
 			"license": "MIT",
 			"dependencies": {
 				"depd": "~1.1.2",
-				"inherits": "2.0.3",
-				"setprototypeof": "1.1.0",
-				"statuses": ">= 1.4.0 < 2"
+				"inherits": "2.0.4",
+				"setprototypeof": "1.2.0",
+				"statuses": ">= 1.5.0 < 2",
+				"toidentifier": "1.0.1"
 			},
 			"engines": {
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/serve-index/node_modules/inherits": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-			"license": "ISC"
+		"node_modules/serve-index/node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/serve-index/node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
 		},
 		"node_modules/serve-index/node_modules/ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"license": "MIT"
-		},
-		"node_modules/serve-index/node_modules/setprototypeof": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-			"license": "ISC"
 		},
 		"node_modules/serve-index/node_modules/statuses": {
 			"version": "1.5.0",
@@ -18147,9 +18345,9 @@
 			"license": "MIT"
 		},
 		"node_modules/sitemap": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.2.tgz",
-			"integrity": "sha512-ARCqzHJ0p4gWt+j7NlU5eDlIO9+Rkr/JhPFZKKQ1l5GCus7rJH4UdrlVAh0xC/gDS/Qir2UMxqYNHtsKr2rpCw==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.3.tgz",
+			"integrity": "sha512-tAjEd+wt/YwnEbfNB2ht51ybBJxbEWwe5ki/Z//Wh0rpBFTCUSj46GnxUKEWzhfuJTsee8x3lybHxFgUMig2hw==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^17.0.5",
@@ -18380,12 +18578,12 @@
 			}
 		},
 		"node_modules/string-width/node_modules/strip-ansi": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
 			"license": "MIT",
 			"dependencies": {
-				"ansi-regex": "^6.0.1"
+				"ansi-regex": "^6.2.2"
 			},
 			"engines": {
 				"node": ">=12"
@@ -18568,19 +18766,6 @@
 				"node": ">= 10"
 			}
 		},
-		"node_modules/swr": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/swr/-/swr-2.3.8.tgz",
-			"integrity": "sha512-gaCPRVoMq8WGDcWj9p4YWzCMPHzE0WNl6W8ADIx9c3JBEIdMkJGMzW+uzXvxHMltwcYACr9jP+32H8/hgwMR7w==",
-			"license": "MIT",
-			"dependencies": {
-				"dequal": "^2.0.3",
-				"use-sync-external-store": "^1.6.0"
-			},
-			"peerDependencies": {
-				"react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-			}
-		},
 		"node_modules/tapable": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
@@ -18595,9 +18780,9 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.45.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.45.0.tgz",
-			"integrity": "sha512-hQ9c+JZEnMug8eqzuU48sCeq95f00lLDAaJ5gWhRkFXsfy3+SUkZXiF/Z66ZO6EomSmgqXnkhVrWXKaQ8K41Ug==",
+			"version": "5.46.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
+			"integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
@@ -18695,18 +18880,6 @@
 			},
 			"peerDependencies": {
 				"tslib": "^2"
-			}
-		},
-		"node_modules/throttleit": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
-			"integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/thunky": {
@@ -18824,8 +18997,7 @@
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"peer": true
+			"license": "0BSD"
 		},
 		"node_modules/tsyringe": {
 			"version": "4.10.0",
@@ -18907,9 +19079,9 @@
 			"license": "MIT"
 		},
 		"node_modules/undici-types": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
 			"license": "MIT"
 		},
 		"node_modules/unicode-canonical-property-names-ecmascript": {
@@ -19048,9 +19220,9 @@
 			}
 		},
 		"node_modules/unist-util-visit": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
-			"integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+			"integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "^3.0.0",
@@ -19235,11 +19407,10 @@
 			}
 		},
 		"node_modules/url-loader/node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -19303,15 +19474,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
-			}
-		},
-		"node_modules/use-sync-external-store": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-			"integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-			"license": "MIT",
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -19458,9 +19620,9 @@
 			"license": "MIT"
 		},
 		"node_modules/vscode-uri": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
-			"integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+			"integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
 			"license": "MIT"
 		},
 		"node_modules/watchpack": {
@@ -19496,11 +19658,10 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.104.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
-			"integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
+			"version": "5.105.3",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.3.tgz",
+			"integrity": "sha512-LLBBA4oLmT7sZdHiYE/PeVuifOxYyE2uL/V+9VQP7YSYdJU7bSf7H8bZRRxW8kEPMkmVjnrXmoR3oejIdX0xbg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
@@ -19508,11 +19669,11 @@
 				"@webassemblyjs/ast": "^1.14.1",
 				"@webassemblyjs/wasm-edit": "^1.14.1",
 				"@webassemblyjs/wasm-parser": "^1.14.1",
-				"acorn": "^8.15.0",
+				"acorn": "^8.16.0",
 				"acorn-import-phases": "^1.0.3",
 				"browserslist": "^4.28.1",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.17.4",
+				"enhanced-resolve": "^5.19.0",
 				"es-module-lexer": "^2.0.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
@@ -19525,8 +19686,8 @@
 				"schema-utils": "^4.3.3",
 				"tapable": "^2.3.0",
 				"terser-webpack-plugin": "^5.3.16",
-				"watchpack": "^2.4.4",
-				"webpack-sources": "^3.3.3"
+				"watchpack": "^2.5.1",
+				"webpack-sources": "^3.3.4"
 			},
 			"bin": {
 				"webpack": "bin/webpack.js"
@@ -19765,9 +19926,9 @@
 			}
 		},
 		"node_modules/webpack-sources": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
-			"integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
+			"integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.13.0"
@@ -19967,12 +20128,12 @@
 			}
 		},
 		"node_modules/wrap-ansi/node_modules/strip-ansi": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
 			"license": "MIT",
 			"dependencies": {
-				"ansi-regex": "^6.0.1"
+				"ansi-regex": "^6.2.2"
 			},
 			"engines": {
 				"node": ">=12"
@@ -20030,9 +20191,9 @@
 			}
 		},
 		"node_modules/wsl-utils/node_modules/is-wsl": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-			"integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+			"integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
 			"license": "MIT",
 			"dependencies": {
 				"is-inside-container": "^1.0.0"
@@ -20084,16 +20245,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/zod": {
-			"version": "4.3.5",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
-			"integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
-			"license": "MIT",
-			"peer": true,
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/zwitch": {


### PR DESCRIPTION
## Summary
- Consolidates Dependabot PRs #731, #749, #753, #754 into a single update
- Ran `npm update` in `/website` to bring all transitive dependencies up to date
- Build verified successfully

### Updated dependencies
- **lodash** 4.17.21 -> 4.17.23
- **qs** 6.14.1 -> 6.14.2
- **mermaid** updated to 11.12.3
- **ajv** updated
- **lodash-es** updated

Closes #731
Closes #749
Closes #753
Closes #754

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Lockfile-only update, but it bumps core build/search/rendering dependencies (Webpack/Babel/PostCSS/Sass, Algolia/DocSearch, Mermaid) and introduces new transitive packages with updated engine constraints (e.g., `langium` now requires newer Node), which could impact the website build environment.
> 
> **Overview**
> Consolidates a broad `npm update` for the `website` by refreshing `package-lock.json`, upgrading many transitive dependencies across the build toolchain and docs UX (notably `webpack`, `@babel/*`, `postcss`/`autoprefixer`, `sass`/`sass-loader`, and Algolia/DocSearch packages).
> 
> Updates Mermaid’s parser stack (`@mermaid-js/parser` → `1.0.0`, `langium` → `4.x`) and cleans up the lockfile by removing previously pulled-in AI/validation deps (e.g., `@ai-sdk/*`, `ai`, `zod`, `swr`) now no longer required by DocSearch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db8f68610f5727381cde4a5bfad80e741e3980b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->