### PR TITLE
fix: guard against nil panics in JWT and watermark paths

### DIFF
--- a/pkg/middlewares/jwt.go
+++ b/pkg/middlewares/jwt.go
@@ -149,17 +149,19 @@ func (j *JWT) GenerateToken(user string, pass string) (string, error) {
 	claims := token.Claims.(jwt.MapClaims)
 	claims["user"] = user
 	ud, ok := j.GetUserData(user)
+	if !ok {
+		return "", fmt.Errorf("JWT: user not found")
+	}
 	if !constantTimeCompare(pass, ud.Password) {
 		ud = ud.NewData
 	}
-	if ok {
-		if ud.Exp == 0 {
-			ud.Exp = 60
-		}
-		claims["exp"] = time.Now().Add(time.Minute * time.Duration(ud.Exp)).Unix()
-	} else {
-		return "", fmt.Errorf("JWT: user not found")
+	if ud == nil {
+		return "", fmt.Errorf("JWT: invalid credentials")
 	}
+	if ud.Exp == 0 {
+		ud.Exp = 60
+	}
+	claims["exp"] = time.Now().Add(time.Minute * time.Duration(ud.Exp)).Unix()
 	token.Claims = claims
 	return token.SignedString([]byte(ud.Secret))
 }

--- a/pkg/middlewares/jwt_test.go
+++ b/pkg/middlewares/jwt_test.go
@@ -435,6 +435,20 @@ func TestAuthenticateWithCredentialRotation(t *testing.T) {
 	})
 }
 
+func TestGenerateTokenNonexistentUser(t *testing.T) {
+	j := &JWT{
+		Users: map[string]UserData{
+			"user": {
+				Password: "pass",
+				Secret:   secret,
+			},
+		},
+	}
+	_, err := j.GenerateToken("ghost", "pass")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "user not found")
+}
+
 func getToken(user string, au *JWTMiddleware) (string, error) {
 
 	req, err := http.NewRequest("GET", "/login", nil)

--- a/pkg/signatory/signatory.go
+++ b/pkg/signatory/signatory.go
@@ -406,7 +406,11 @@ func (s *Signatory) Sign(ctx context.Context, req *SignRequest) (crypt.Signature
 
 		if wmErr != nil {
 			err = errors.Wrap(wmErr, http.StatusConflict)
-			metrics.WatermarkRejection(req.PublicKeyHash.String(), msg.SignRequestKind(), msg.(request.WithWatermark).GetChainID().String(), err.Error())
+			chainIDStr := ""
+			if m, ok := msg.(request.WithWatermark); ok {
+				chainIDStr = m.GetChainID().String()
+			}
+			metrics.WatermarkRejection(req.PublicKeyHash.String(), msg.SignRequestKind(), chainIDStr, wmErr.Error())
 			l.Error(err)
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
- **`pkg/middlewares/jwt.go`**: `GenerateToken` dereferenced `ud.Password` before checking the `ok` return from `GetUserData`. If the user doesn't exist, this is a nil dereference. Moved the `ok` guard before any use of `ud`, and added a second nil check after the `NewData` fallback assignment.
- **`pkg/signatory/signatory.go`**: The watermark rejection metrics call used a bare type assertion `msg.(request.WithWatermark)` that would panic if `msg` doesn't implement `WithWatermark`. Replaced with the same comma-ok guard used a few lines below. Also switched from `err.Error()` (HTTP-wrapped) to `wmErr.Error()` (raw watermark error) for the metric label.
- Added `TestGenerateTokenNonexistentUser` to exercise the new nil guard directly.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/middlewares/...` (all pass, including new test)
- [x] `go test ./pkg/signatory/...` (all pass)