### PR TITLE
chore(website): bump deps and fix broken docs LICENSE link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ This directory contains the documentation for [Signatory](https://signatory.io),
 
 All content in this directory and its subdirectories — including documentation, written content, tutorials, guides, and images — is the exclusive property of **ECAD Labs Inc.** All rights reserved.
 
-See [LICENSE](LICENSE) in this directory for the full proprietary license terms.
+See [LICENSE](https://github.com/ecadlabs/signatory/blob/main/docs/LICENSE) in this directory for the full proprietary license terms.
 
 ## Contact
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -22,46 +22,46 @@
 			}
 		},
 		"node_modules/@algolia/abtesting": {
-			"version": "1.15.1",
-			"resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.15.1.tgz",
-			"integrity": "sha512-2yuIC48rUuHGhU1U5qJ9kJHaxYpJ0jpDHJVI5ekOxSMYXlH4+HP+pA31G820lsAznfmu2nzDV7n5RO44zIY1zw==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.16.2.tgz",
+			"integrity": "sha512-n9s6bEV6imdtIEd+BGP7WkA4pEZ5YTdgQ05JQhHwWawHg3hyjpNwC0TShGz6zWhv+jfLDGA/6FFNbySFS0P9cw==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.49.1",
-				"@algolia/requester-browser-xhr": "5.49.1",
-				"@algolia/requester-fetch": "5.49.1",
-				"@algolia/requester-node-http": "5.49.1"
+				"@algolia/client-common": "5.50.2",
+				"@algolia/requester-browser-xhr": "5.50.2",
+				"@algolia/requester-fetch": "5.50.2",
+				"@algolia/requester-node-http": "5.50.2"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/autocomplete-core": {
-			"version": "1.19.2",
-			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.2.tgz",
-			"integrity": "sha512-mKv7RyuAzXvwmq+0XRK8HqZXt9iZ5Kkm2huLjgn5JoCPtDy+oh9yxUMfDDaVCw0oyzZ1isdJBc7l9nuCyyR7Nw==",
+			"version": "1.19.8",
+			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.8.tgz",
+			"integrity": "sha512-3YEorYg44niXcm7gkft3nXYItHd44e8tmh4D33CTszPgP0QWkaLEaFywiNyJBo7UL/mqObA/G9RYuU7R8tN1IA==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/autocomplete-plugin-algolia-insights": "1.19.2",
-				"@algolia/autocomplete-shared": "1.19.2"
+				"@algolia/autocomplete-plugin-algolia-insights": "1.19.8",
+				"@algolia/autocomplete-shared": "1.19.8"
 			}
 		},
 		"node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-			"version": "1.19.2",
-			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.2.tgz",
-			"integrity": "sha512-TjxbcC/r4vwmnZaPwrHtkXNeqvlpdyR+oR9Wi2XyfORkiGkLTVhX2j+O9SaCCINbKoDfc+c2PB8NjfOnz7+oKg==",
+			"version": "1.19.8",
+			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.8.tgz",
+			"integrity": "sha512-ZvJWO8ZZJDpc1LNM2TTBdmQsZBLMR4rU5iNR2OYvEeFBiaf/0ESnRSSLQbryarJY4SVxtoz6A2ZtDMNM+iQEAA==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/autocomplete-shared": "1.19.2"
+				"@algolia/autocomplete-shared": "1.19.8"
 			},
 			"peerDependencies": {
 				"search-insights": ">= 1 < 3"
 			}
 		},
 		"node_modules/@algolia/autocomplete-shared": {
-			"version": "1.19.2",
-			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.2.tgz",
-			"integrity": "sha512-jEazxZTVD2nLrC+wYlVHQgpBoBB5KPStrJxLzsIFl6Kqd1AlG9sIAGl39V5tECLpIQzB3Qa2T6ZPJ1ChkwMK/w==",
+			"version": "1.19.8",
+			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.8.tgz",
+			"integrity": "sha512-h5hf2t8ejF6vlOgvLaZzQbWs5SyH2z4PAWygNAvvD/2RI29hdQ54ldUGwqVuj9Srs+n8XUKTPUqb7fvhBhQrnQ==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@algolia/client-search": ">= 4.9.1 < 6",
@@ -69,99 +69,99 @@
 			}
 		},
 		"node_modules/@algolia/client-abtesting": {
-			"version": "5.49.1",
-			"resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.49.1.tgz",
-			"integrity": "sha512-h6M7HzPin+45/l09q0r2dYmocSSt2MMGOOk5c4O5K/bBBlEwf1BKfN6z+iX4b8WXcQQhf7rgQwC52kBZJt/ZZw==",
+			"version": "5.50.2",
+			"resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.50.2.tgz",
+			"integrity": "sha512-52iq0vHy1sphgnwoZyx5PmbEt8hsh+m7jD123LmBs6qy4GK7LbYZIeKd+nSnSipN2zvKRZ2zScS6h9PW3J7SXg==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.49.1",
-				"@algolia/requester-browser-xhr": "5.49.1",
-				"@algolia/requester-fetch": "5.49.1",
-				"@algolia/requester-node-http": "5.49.1"
+				"@algolia/client-common": "5.50.2",
+				"@algolia/requester-browser-xhr": "5.50.2",
+				"@algolia/requester-fetch": "5.50.2",
+				"@algolia/requester-node-http": "5.50.2"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-analytics": {
-			"version": "5.49.1",
-			"resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.49.1.tgz",
-			"integrity": "sha512-048T9/Z8OeLmTk8h76QUqaNFp7Rq2VgS2Zm6Y2tNMYGQ1uNuzePY/udB5l5krlXll7ZGflyCjFvRiOtlPZpE9g==",
+			"version": "5.50.2",
+			"resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.50.2.tgz",
+			"integrity": "sha512-WpPIUg+cSG2aPUG0gS8Ko9DwRgbRPUZxJkolhL2aCsmSlcEEZT65dILrfg5ovcxtx0Kvr+xtBVsTMtsQWRtPDQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.49.1",
-				"@algolia/requester-browser-xhr": "5.49.1",
-				"@algolia/requester-fetch": "5.49.1",
-				"@algolia/requester-node-http": "5.49.1"
+				"@algolia/client-common": "5.50.2",
+				"@algolia/requester-browser-xhr": "5.50.2",
+				"@algolia/requester-fetch": "5.50.2",
+				"@algolia/requester-node-http": "5.50.2"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-common": {
-			"version": "5.49.1",
-			"resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.49.1.tgz",
-			"integrity": "sha512-vp5/a9ikqvf3mn9QvHN8PRekn8hW34aV9eX+O0J5mKPZXeA6Pd5OQEh2ZWf7gJY6yyfTlLp5LMFzQUAU+Fpqpg==",
+			"version": "5.50.2",
+			"resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.50.2.tgz",
+			"integrity": "sha512-Gj2MgtArGcsr82kIqRlo6/dCAFjrs2gLByEqyRENuT7ugrSMFuqg1vDzeBjRL1t3EJEJCFtT0PLX3gB8A6Hq4Q==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-insights": {
-			"version": "5.49.1",
-			"resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.49.1.tgz",
-			"integrity": "sha512-B6N7PgkvYrul3bntTz/l6uXnhQ2bvP+M7NqTcayh681tSqPaA5cJCUBp/vrP7vpPRpej4Eeyx2qz5p0tE/2N2g==",
+			"version": "5.50.2",
+			"resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.50.2.tgz",
+			"integrity": "sha512-CUqoid5jDpmrc0oK3/xuZXFt6kwT0P9Lw7/nsM14YTr6puvmi+OUKmURpmebQF22S2vCG8L1DAoXXujxQUi/ug==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.49.1",
-				"@algolia/requester-browser-xhr": "5.49.1",
-				"@algolia/requester-fetch": "5.49.1",
-				"@algolia/requester-node-http": "5.49.1"
+				"@algolia/client-common": "5.50.2",
+				"@algolia/requester-browser-xhr": "5.50.2",
+				"@algolia/requester-fetch": "5.50.2",
+				"@algolia/requester-node-http": "5.50.2"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-personalization": {
-			"version": "5.49.1",
-			"resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.49.1.tgz",
-			"integrity": "sha512-v+4DN+lkYfBd01Hbnb9ZrCHe7l+mvihyx218INRX/kaCXROIWUDIT1cs3urQxfE7kXBFnLsqYeOflQALv/gA5w==",
+			"version": "5.50.2",
+			"resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.50.2.tgz",
+			"integrity": "sha512-AndZWFoc0gbP5901OeQJ73BazgGgSGiBEba4ohdoJuZwHTO2Gio8Q4L1VLmytMBYcviVigB0iICToMvEJxI4ug==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.49.1",
-				"@algolia/requester-browser-xhr": "5.49.1",
-				"@algolia/requester-fetch": "5.49.1",
-				"@algolia/requester-node-http": "5.49.1"
+				"@algolia/client-common": "5.50.2",
+				"@algolia/requester-browser-xhr": "5.50.2",
+				"@algolia/requester-fetch": "5.50.2",
+				"@algolia/requester-node-http": "5.50.2"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-query-suggestions": {
-			"version": "5.49.1",
-			"resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.49.1.tgz",
-			"integrity": "sha512-Un11cab6ZCv0W+Jiak8UktGIqoa4+gSNgEZNfG8m8eTsXGqwIEr370H3Rqwj87zeNSlFpH2BslMXJ/cLNS1qtg==",
+			"version": "5.50.2",
+			"resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.50.2.tgz",
+			"integrity": "sha512-NWoL+psEkz5dIzweaByVXuEB45wS8/rk0E0AhMMnaVJdVs7TcACPH2/OURm+N0xRDITkTHqCna823rd6Uqntdg==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.49.1",
-				"@algolia/requester-browser-xhr": "5.49.1",
-				"@algolia/requester-fetch": "5.49.1",
-				"@algolia/requester-node-http": "5.49.1"
+				"@algolia/client-common": "5.50.2",
+				"@algolia/requester-browser-xhr": "5.50.2",
+				"@algolia/requester-fetch": "5.50.2",
+				"@algolia/requester-node-http": "5.50.2"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-search": {
-			"version": "5.49.1",
-			"resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.49.1.tgz",
-			"integrity": "sha512-Nt9hri7nbOo0RipAsGjIssHkpLMHHN/P7QqENywAq5TLsoYDzUyJGny8FEiD/9KJUxtGH8blGpMedilI6kK3rA==",
+			"version": "5.50.2",
+			"resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.50.2.tgz",
+			"integrity": "sha512-ypSboUJ3XJoQz5DeDo82hCnrRuwq3q9ZdFhVKAik9TnZh1DvLqoQsrbBjXg7C7zQOtV/Qbge/HmyoV6V5L7MhQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.49.1",
-				"@algolia/requester-browser-xhr": "5.49.1",
-				"@algolia/requester-fetch": "5.49.1",
-				"@algolia/requester-node-http": "5.49.1"
+				"@algolia/client-common": "5.50.2",
+				"@algolia/requester-browser-xhr": "5.50.2",
+				"@algolia/requester-fetch": "5.50.2",
+				"@algolia/requester-node-http": "5.50.2"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
@@ -174,81 +174,81 @@
 			"license": "MIT"
 		},
 		"node_modules/@algolia/ingestion": {
-			"version": "1.49.1",
-			"resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.49.1.tgz",
-			"integrity": "sha512-b5hUXwDqje0Y4CpU6VL481DXgPgxpTD5sYMnfQTHKgUispGnaCLCm2/T9WbJo1YNUbX3iHtYDArp804eD6CmRQ==",
+			"version": "1.50.2",
+			"resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.50.2.tgz",
+			"integrity": "sha512-VlR2FRXLw2bCB94SQo6zxg/Qi+547aOji6Pb+dKE7h1DMCCY317St+OpjpmgzE+bT2O9ALIc0V4nVIBOd7Gy+Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.49.1",
-				"@algolia/requester-browser-xhr": "5.49.1",
-				"@algolia/requester-fetch": "5.49.1",
-				"@algolia/requester-node-http": "5.49.1"
+				"@algolia/client-common": "5.50.2",
+				"@algolia/requester-browser-xhr": "5.50.2",
+				"@algolia/requester-fetch": "5.50.2",
+				"@algolia/requester-node-http": "5.50.2"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/monitoring": {
-			"version": "1.49.1",
-			"resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.49.1.tgz",
-			"integrity": "sha512-bvrXwZ0WsL3rN6Q4m4QqxsXFCo6WAew7sAdrpMQMK4Efn4/W920r9ptOuckejOSSvyLr9pAWgC5rsHhR2FYuYw==",
+			"version": "1.50.2",
+			"resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.50.2.tgz",
+			"integrity": "sha512-Cmvfp2+qopzQt8OilU97rhLhosq7ZrB6uieok3EwFUqG/aalPg6DgfCmu0yJMrYe+KMC1qRVt1MTRAUwLknUMQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.49.1",
-				"@algolia/requester-browser-xhr": "5.49.1",
-				"@algolia/requester-fetch": "5.49.1",
-				"@algolia/requester-node-http": "5.49.1"
+				"@algolia/client-common": "5.50.2",
+				"@algolia/requester-browser-xhr": "5.50.2",
+				"@algolia/requester-fetch": "5.50.2",
+				"@algolia/requester-node-http": "5.50.2"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/recommend": {
-			"version": "5.49.1",
-			"resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.49.1.tgz",
-			"integrity": "sha512-h2yz3AGeGkQwNgbLmoe3bxYs8fac4An1CprKTypYyTU/k3Q+9FbIvJ8aS1DoBKaTjSRZVoyQS7SZQio6GaHbZw==",
+			"version": "5.50.2",
+			"resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.50.2.tgz",
+			"integrity": "sha512-jrkuyKoOM7dFWQ/6Y4hQAse2SC3L/RldG6GnPjMvAj65h+7Ubb51S0pKk4ofSStF0xm4LCNe0C4T6XX4nOFDiQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.49.1",
-				"@algolia/requester-browser-xhr": "5.49.1",
-				"@algolia/requester-fetch": "5.49.1",
-				"@algolia/requester-node-http": "5.49.1"
+				"@algolia/client-common": "5.50.2",
+				"@algolia/requester-browser-xhr": "5.50.2",
+				"@algolia/requester-fetch": "5.50.2",
+				"@algolia/requester-node-http": "5.50.2"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/requester-browser-xhr": {
-			"version": "5.49.1",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.49.1.tgz",
-			"integrity": "sha512-2UPyRuUR/qpqSqH8mxFV5uBZWEpxhGPHLlx9Xf6OVxr79XO2ctzZQAhsmTZ6X22x+N8MBWpB9UEky7YU2HGFgA==",
+			"version": "5.50.2",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.50.2.tgz",
+			"integrity": "sha512-4107YLJqCudPiBUlwnk6oTSUVwU7ab+qL1SfQGEDYI8DZH5gsf1ekPt9JykXRKYXf2IfouFL5GiCY/PHTFIjYw==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.49.1"
+				"@algolia/client-common": "5.50.2"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/requester-fetch": {
-			"version": "5.49.1",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.49.1.tgz",
-			"integrity": "sha512-N+xlE4lN+wpuT+4vhNEwPVlrfN+DWAZmSX9SYhbz986Oq8AMsqdntOqUyiOXVxYsQtfLwmiej24vbvJGYv1Qtw==",
+			"version": "5.50.2",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.50.2.tgz",
+			"integrity": "sha512-vOrd3MQpLgmf6wXAueTuZ/cA0W4uRwIHHaxNy3h+a6YcNn6bCV/gFdZuv3F13v593zRU2k5R75NmvRWLenvMrw==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.49.1"
+				"@algolia/client-common": "5.50.2"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/requester-node-http": {
-			"version": "5.49.1",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.49.1.tgz",
-			"integrity": "sha512-zA5bkUOB5PPtTr182DJmajCiizHp0rCJQ0Chf96zNFvkdESKYlDeYA3tQ7r2oyHbu/8DiohAQ5PZ85edctzbXA==",
+			"version": "5.50.2",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.50.2.tgz",
+			"integrity": "sha512-Mu9BFtgzGqDUy5Bcs2nMyoILIFSN13GKQaklKAFIsd0K3/9CpNyfeBc+/+Qs6mFZLlxG9qzullO7h+bjcTBuGQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.49.1"
+				"@algolia/client-common": "5.50.2"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
@@ -439,9 +439,9 @@
 			}
 		},
 		"node_modules/@babel/helper-define-polyfill-provider": {
-			"version": "0.6.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.6.tgz",
-			"integrity": "sha512-mOAsxeeKkUKayvZR3HeTYD/fICpCPLJrU5ZjelT/PA6WHtNDBOE436YiaEUvHN454bRM3CebhDsIpieCc4texA==",
+			"version": "0.6.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
+			"integrity": "sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-compilation-targets": "^7.28.6",
@@ -616,22 +616,22 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-			"integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+			"integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/template": "^7.28.6",
-				"@babel/types": "^7.28.6"
+				"@babel/types": "^7.29.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-			"integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+			"integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/types": "^7.29.0"
@@ -1756,9 +1756,9 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.0.tgz",
-			"integrity": "sha512-fNEdfc0yi16lt6IZo2Qxk3knHVdfMYX33czNb4v8yWhemoBhibCpQK/uYHtSKIiO+p/zd3+8fYVXhQdOVV608w==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.2.tgz",
+			"integrity": "sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/compat-data": "^7.29.0",
@@ -1840,12 +1840,12 @@
 			}
 		},
 		"node_modules/@babel/preset-env/node_modules/babel-plugin-polyfill-corejs3": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.0.tgz",
-			"integrity": "sha512-AvDcMxJ34W4Wgy4KBIIePQTAOP1Ie2WFwkQp3dB7FQ/f0lI5+nM96zUnYEOE1P9sEg0es5VCP0HxiWu5fUHZAQ==",
+			"version": "0.14.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz",
+			"integrity": "sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.6.6",
+				"@babel/helper-define-polyfill-provider": "^0.6.8",
 				"core-js-compat": "^3.48.0"
 			},
 			"peerDependencies": {
@@ -1923,18 +1923,6 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/runtime-corejs3": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.0.tgz",
-			"integrity": "sha512-TgUkdp71C9pIbBcHudc+gXZnihEDOjUAmXO1VO4HHGES7QLZcShR0stfKIxLSNIYx2fqhmJChOjm/wkF8wv4gA==",
-			"license": "MIT",
-			"dependencies": {
-				"core-js-pure": "^3.48.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/template": {
 			"version": "7.28.6",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -1987,42 +1975,40 @@
 			"license": "MIT"
 		},
 		"node_modules/@chevrotain/cst-dts-gen": {
-			"version": "11.1.2",
-			"resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.1.2.tgz",
-			"integrity": "sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
+			"integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@chevrotain/gast": "11.1.2",
-				"@chevrotain/types": "11.1.2",
-				"lodash-es": "4.17.23"
+				"@chevrotain/gast": "12.0.0",
+				"@chevrotain/types": "12.0.0"
 			}
 		},
 		"node_modules/@chevrotain/gast": {
-			"version": "11.1.2",
-			"resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.1.2.tgz",
-			"integrity": "sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
+			"integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@chevrotain/types": "11.1.2",
-				"lodash-es": "4.17.23"
+				"@chevrotain/types": "12.0.0"
 			}
 		},
 		"node_modules/@chevrotain/regexp-to-ast": {
-			"version": "11.1.2",
-			"resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.1.2.tgz",
-			"integrity": "sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
+			"integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@chevrotain/types": {
-			"version": "11.1.2",
-			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
-			"integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
+			"integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@chevrotain/utils": {
-			"version": "11.1.2",
-			"resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.2.tgz",
-			"integrity": "sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
+			"integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@colors/colors": {
@@ -3361,9 +3347,9 @@
 			}
 		},
 		"node_modules/@docsearch/core": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.6.0.tgz",
-			"integrity": "sha512-IqG3oSd529jVRQ4dWZQKwZwQLVd//bWJTz2HiL0LkiHrI4U/vLrBasKB7lwQB/69nBAcCgs3TmudxTZSLH/ZQg==",
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.6.2.tgz",
+			"integrity": "sha512-/S0e6Dj7Zcm8m9Rru49YEX49dhU11be68c+S/BCyN8zQsTTgkKzXlhRbVL5mV6lOLC2+ZRRryaTdcm070Ug2oA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": ">= 16.8.0 < 20.0.0",
@@ -3383,20 +3369,20 @@
 			}
 		},
 		"node_modules/@docsearch/css": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.6.0.tgz",
-			"integrity": "sha512-YlcAimkXclvqta47g47efzCM5CFxDwv2ClkDfEs/fC/Ak0OxPH2b3czwa4o8O1TRBf+ujFF2RiUwszz2fPVNJQ==",
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.6.2.tgz",
+			"integrity": "sha512-fH/cn8BjEEdM2nJdjNMHIvOVYupG6AIDtFVDgIZrNzdCSj4KXr9kd+hsehqsNGYjpUjObeKYKvgy/IwCb1jZYQ==",
 			"license": "MIT"
 		},
 		"node_modules/@docsearch/react": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.6.0.tgz",
-			"integrity": "sha512-j8H5B4ArGxBPBWvw3X0J0Rm/Pjv2JDa2rV5OE0DLTp5oiBCptIJ/YlNOhZxuzbO2nwge+o3Z52nJRi3hryK9cA==",
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.6.2.tgz",
+			"integrity": "sha512-/BbtGFtqVOGwZx0dw/UfhN/0/DmMQYnulY4iv0tPRhC2JCXv0ka/+izwt3Jzo1ZxXS/2eMvv9zHsBJOK1I9f/w==",
 			"license": "MIT",
 			"dependencies": {
 				"@algolia/autocomplete-core": "1.19.2",
-				"@docsearch/core": "4.6.0",
-				"@docsearch/css": "4.6.0"
+				"@docsearch/core": "4.6.2",
+				"@docsearch/css": "4.6.2"
 			},
 			"peerDependencies": {
 				"@types/react": ">= 16.8.0 < 20.0.0",
@@ -3419,10 +3405,42 @@
 				}
 			}
 		},
+		"node_modules/@docsearch/react/node_modules/@algolia/autocomplete-core": {
+			"version": "1.19.2",
+			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.2.tgz",
+			"integrity": "sha512-mKv7RyuAzXvwmq+0XRK8HqZXt9iZ5Kkm2huLjgn5JoCPtDy+oh9yxUMfDDaVCw0oyzZ1isdJBc7l9nuCyyR7Nw==",
+			"license": "MIT",
+			"dependencies": {
+				"@algolia/autocomplete-plugin-algolia-insights": "1.19.2",
+				"@algolia/autocomplete-shared": "1.19.2"
+			}
+		},
+		"node_modules/@docsearch/react/node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+			"version": "1.19.2",
+			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.2.tgz",
+			"integrity": "sha512-TjxbcC/r4vwmnZaPwrHtkXNeqvlpdyR+oR9Wi2XyfORkiGkLTVhX2j+O9SaCCINbKoDfc+c2PB8NjfOnz7+oKg==",
+			"license": "MIT",
+			"dependencies": {
+				"@algolia/autocomplete-shared": "1.19.2"
+			},
+			"peerDependencies": {
+				"search-insights": ">= 1 < 3"
+			}
+		},
+		"node_modules/@docsearch/react/node_modules/@algolia/autocomplete-shared": {
+			"version": "1.19.2",
+			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.2.tgz",
+			"integrity": "sha512-jEazxZTVD2nLrC+wYlVHQgpBoBB5KPStrJxLzsIFl6Kqd1AlG9sIAGl39V5tECLpIQzB3Qa2T6ZPJ1ChkwMK/w==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@algolia/client-search": ">= 4.9.1 < 6",
+				"algoliasearch": ">= 4.9.1 < 6"
+			}
+		},
 		"node_modules/@docusaurus/babel": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.9.2.tgz",
-			"integrity": "sha512-GEANdi/SgER+L7Japs25YiGil/AUDnFFHaCGPBbundxoWtCkA2lmy7/tFmgED4y1htAy6Oi4wkJEQdGssnw9MA==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.10.0.tgz",
+			"integrity": "sha512-mqCJhCZNZUDg0zgDEaPTM4DnRsisa24HdqTy/qn/MQlbwhTb4WVaZg6ZyX6yIVKqTz8fS1hBMgM+98z+BeJJDg==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/core": "^7.25.9",
@@ -3433,10 +3451,9 @@
 				"@babel/preset-react": "^7.25.9",
 				"@babel/preset-typescript": "^7.25.9",
 				"@babel/runtime": "^7.25.9",
-				"@babel/runtime-corejs3": "^7.25.9",
 				"@babel/traverse": "^7.25.9",
-				"@docusaurus/logger": "3.9.2",
-				"@docusaurus/utils": "3.9.2",
+				"@docusaurus/logger": "3.10.0",
+				"@docusaurus/utils": "3.10.0",
 				"babel-plugin-dynamic-import-node": "^2.3.3",
 				"fs-extra": "^11.1.1",
 				"tslib": "^2.6.0"
@@ -3446,17 +3463,17 @@
 			}
 		},
 		"node_modules/@docusaurus/bundler": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.9.2.tgz",
-			"integrity": "sha512-ZOVi6GYgTcsZcUzjblpzk3wH1Fya2VNpd5jtHoCCFcJlMQ1EYXZetfAnRHLcyiFeBABaI1ltTYbOBtH/gahGVA==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.10.0.tgz",
+			"integrity": "sha512-iONUGZGgp+lAkw/cJZH6irONcF4p8+278IsdRlq8lYhxGjkoNUs0w7F4gVXBYSNChq5KG5/JleTSsdJySShxow==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/core": "^7.25.9",
-				"@docusaurus/babel": "3.9.2",
-				"@docusaurus/cssnano-preset": "3.9.2",
-				"@docusaurus/logger": "3.9.2",
-				"@docusaurus/types": "3.9.2",
-				"@docusaurus/utils": "3.9.2",
+				"@docusaurus/babel": "3.10.0",
+				"@docusaurus/cssnano-preset": "3.10.0",
+				"@docusaurus/logger": "3.10.0",
+				"@docusaurus/types": "3.10.0",
+				"@docusaurus/utils": "3.10.0",
 				"babel-loader": "^9.2.1",
 				"clean-css": "^5.3.3",
 				"copy-webpack-plugin": "^11.0.0",
@@ -3489,18 +3506,18 @@
 			}
 		},
 		"node_modules/@docusaurus/core": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.9.2.tgz",
-			"integrity": "sha512-HbjwKeC+pHUFBfLMNzuSjqFE/58+rLVKmOU3lxQrpsxLBOGosYco/Q0GduBb0/jEMRiyEqjNT/01rRdOMWq5pw==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.10.0.tgz",
+			"integrity": "sha512-mgLdQsO8xppnQZc3LPi+Mf+PkPeyxJeIx11AXAq/14fsaMefInQiMEZUUmrc7J+956G/f7MwE7tn8KZgi3iRcA==",
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/babel": "3.9.2",
-				"@docusaurus/bundler": "3.9.2",
-				"@docusaurus/logger": "3.9.2",
-				"@docusaurus/mdx-loader": "3.9.2",
-				"@docusaurus/utils": "3.9.2",
-				"@docusaurus/utils-common": "3.9.2",
-				"@docusaurus/utils-validation": "3.9.2",
+				"@docusaurus/babel": "3.10.0",
+				"@docusaurus/bundler": "3.10.0",
+				"@docusaurus/logger": "3.10.0",
+				"@docusaurus/mdx-loader": "3.10.0",
+				"@docusaurus/utils": "3.10.0",
+				"@docusaurus/utils-common": "3.10.0",
+				"@docusaurus/utils-validation": "3.10.0",
 				"boxen": "^6.2.1",
 				"chalk": "^4.1.2",
 				"chokidar": "^3.5.3",
@@ -3512,7 +3529,7 @@
 				"escape-html": "^1.0.3",
 				"eta": "^2.2.0",
 				"eval": "^0.1.8",
-				"execa": "5.1.1",
+				"execa": "^5.1.1",
 				"fs-extra": "^11.1.1",
 				"html-tags": "^3.3.1",
 				"html-webpack-plugin": "^5.6.0",
@@ -3523,12 +3540,12 @@
 				"prompts": "^2.4.2",
 				"react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
 				"react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-				"react-loadable-ssr-addon-v5-slorber": "^1.0.1",
+				"react-loadable-ssr-addon-v5-slorber": "^1.0.3",
 				"react-router": "^5.3.4",
 				"react-router-config": "^5.1.1",
 				"react-router-dom": "^5.3.4",
 				"semver": "^7.5.4",
-				"serve-handler": "^6.1.6",
+				"serve-handler": "^6.1.7",
 				"tinypool": "^1.0.2",
 				"tslib": "^2.6.0",
 				"update-notifier": "^6.0.2",
@@ -3544,15 +3561,21 @@
 				"node": ">=20.0"
 			},
 			"peerDependencies": {
+				"@docusaurus/faster": "*",
 				"@mdx-js/react": "^3.0.0",
 				"react": "^18.0.0 || ^19.0.0",
 				"react-dom": "^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@docusaurus/faster": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@docusaurus/cssnano-preset": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.9.2.tgz",
-			"integrity": "sha512-8gBKup94aGttRduABsj7bpPFTX7kbwu+xh3K9NMCF5K4bWBqTFYW+REKHF6iBVDHRJ4grZdIPbvkiHd/XNKRMQ==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.10.0.tgz",
+			"integrity": "sha512-qzSshTO1DB3TYW+dPUal5KHM7XPc5YQfzF3Kdb2NDACJUyGbNcFtw3tGkCJlYwhNCRKbZcmwraKUS1i5dcHdGg==",
 			"license": "MIT",
 			"dependencies": {
 				"cssnano-preset-advanced": "^6.1.2",
@@ -3565,9 +3588,9 @@
 			}
 		},
 		"node_modules/@docusaurus/logger": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.9.2.tgz",
-			"integrity": "sha512-/SVCc57ByARzGSU60c50rMyQlBuMIJCjcsJlkphxY6B0GV4UH3tcA1994N8fFfbJ9kX3jIBe/xg3XP5qBtGDbA==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.10.0.tgz",
+			"integrity": "sha512-9jrZzFuBH1LDRlZ7cznAhCLmAZ3HSDqgwdrSSZdGHq9SPUOQgXXu8mnxe2ZRB9NS1PCpMTIOVUqDtZPIhMafZg==",
 			"license": "MIT",
 			"dependencies": {
 				"chalk": "^4.1.2",
@@ -3578,14 +3601,14 @@
 			}
 		},
 		"node_modules/@docusaurus/mdx-loader": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.9.2.tgz",
-			"integrity": "sha512-wiYoGwF9gdd6rev62xDU8AAM8JuLI/hlwOtCzMmYcspEkzecKrP8J8X+KpYnTlACBUUtXNJpSoCwFWJhLRevzQ==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.10.0.tgz",
+			"integrity": "sha512-mQQV97080AH4PYNs087l202NMDqRopZA4mg5W76ZZyTFrmWhJ3mHg+8A+drJVENxw5/Q+wHMHLgsx+9z1nEs0A==",
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/logger": "3.9.2",
-				"@docusaurus/utils": "3.9.2",
-				"@docusaurus/utils-validation": "3.9.2",
+				"@docusaurus/logger": "3.10.0",
+				"@docusaurus/utils": "3.10.0",
+				"@docusaurus/utils-validation": "3.10.0",
 				"@mdx-js/mdx": "^3.0.0",
 				"@slorber/remark-comment": "^1.0.0",
 				"escape-html": "^1.0.3",
@@ -3617,12 +3640,12 @@
 			}
 		},
 		"node_modules/@docusaurus/module-type-aliases": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.2.tgz",
-			"integrity": "sha512-8qVe2QA9hVLzvnxP46ysuofJUIc/yYQ82tvA/rBTrnpXtCjNSFLxEZfd5U8cYZuJIVlkPxamsIgwd5tGZXfvew==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.0.tgz",
+			"integrity": "sha512-/1O0Zg8w3DFrYX/I6Fbss7OJrtZw1QoyjDhegiFNHVi9A9Y0gQ3jUAytVxF6ywpAWpLyLxch8nN8H/V3XfzdJQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/types": "3.9.2",
+				"@docusaurus/types": "3.10.0",
 				"@types/history": "^4.7.11",
 				"@types/react": "*",
 				"@types/react-router-config": "*",
@@ -3636,20 +3659,21 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-content-blog": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.9.2.tgz",
-			"integrity": "sha512-3I2HXy3L1QcjLJLGAoTvoBnpOwa6DPUa3Q0dMK19UTY9mhPkKQg/DYhAGTiBUKcTR0f08iw7kLPqOhIgdV3eVQ==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.10.0.tgz",
+			"integrity": "sha512-RuTz68DhB7CL96QO5UsFbciD7GPYq6QV+YMfF9V0+N4ZgLhJIBgpVAr8GobrKF6NRe5cyWWETU5z5T834piG9g==",
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.9.2",
-				"@docusaurus/logger": "3.9.2",
-				"@docusaurus/mdx-loader": "3.9.2",
-				"@docusaurus/theme-common": "3.9.2",
-				"@docusaurus/types": "3.9.2",
-				"@docusaurus/utils": "3.9.2",
-				"@docusaurus/utils-common": "3.9.2",
-				"@docusaurus/utils-validation": "3.9.2",
+				"@docusaurus/core": "3.10.0",
+				"@docusaurus/logger": "3.10.0",
+				"@docusaurus/mdx-loader": "3.10.0",
+				"@docusaurus/theme-common": "3.10.0",
+				"@docusaurus/types": "3.10.0",
+				"@docusaurus/utils": "3.10.0",
+				"@docusaurus/utils-common": "3.10.0",
+				"@docusaurus/utils-validation": "3.10.0",
 				"cheerio": "1.0.0-rc.12",
+				"combine-promises": "^1.1.0",
 				"feed": "^4.2.2",
 				"fs-extra": "^11.1.1",
 				"lodash": "^4.17.21",
@@ -3670,20 +3694,20 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-content-docs": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
-			"integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.0.tgz",
+			"integrity": "sha512-9BjHhf15ct8Z7TThTC0xRndKDVvMKmVsAGAN7W9FpNRzfMdScOGcXtLmcCWtJGvAezjOJIm6CxOYCy3Io5+RnQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.9.2",
-				"@docusaurus/logger": "3.9.2",
-				"@docusaurus/mdx-loader": "3.9.2",
-				"@docusaurus/module-type-aliases": "3.9.2",
-				"@docusaurus/theme-common": "3.9.2",
-				"@docusaurus/types": "3.9.2",
-				"@docusaurus/utils": "3.9.2",
-				"@docusaurus/utils-common": "3.9.2",
-				"@docusaurus/utils-validation": "3.9.2",
+				"@docusaurus/core": "3.10.0",
+				"@docusaurus/logger": "3.10.0",
+				"@docusaurus/mdx-loader": "3.10.0",
+				"@docusaurus/module-type-aliases": "3.10.0",
+				"@docusaurus/theme-common": "3.10.0",
+				"@docusaurus/types": "3.10.0",
+				"@docusaurus/utils": "3.10.0",
+				"@docusaurus/utils-common": "3.10.0",
+				"@docusaurus/utils-validation": "3.10.0",
 				"@types/react-router-config": "^5.0.7",
 				"combine-promises": "^1.1.0",
 				"fs-extra": "^11.1.1",
@@ -3703,16 +3727,16 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-content-pages": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.9.2.tgz",
-			"integrity": "sha512-s4849w/p4noXUrGpPUF0BPqIAfdAe76BLaRGAGKZ1gTDNiGxGcpsLcwJ9OTi1/V8A+AzvsmI9pkjie2zjIQZKA==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.10.0.tgz",
+			"integrity": "sha512-5amX8kEJI+nIGtuLVjYk59Y5utEJ3CHETFOPEE4cooIRLA4xM4iBsA6zFgu4ljcopeYwvBzFEWf5g2I6Yb9SkA==",
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.9.2",
-				"@docusaurus/mdx-loader": "3.9.2",
-				"@docusaurus/types": "3.9.2",
-				"@docusaurus/utils": "3.9.2",
-				"@docusaurus/utils-validation": "3.9.2",
+				"@docusaurus/core": "3.10.0",
+				"@docusaurus/mdx-loader": "3.10.0",
+				"@docusaurus/types": "3.10.0",
+				"@docusaurus/utils": "3.10.0",
+				"@docusaurus/utils-validation": "3.10.0",
 				"fs-extra": "^11.1.1",
 				"tslib": "^2.6.0",
 				"webpack": "^5.88.1"
@@ -3726,15 +3750,15 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-css-cascade-layers": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.9.2.tgz",
-			"integrity": "sha512-w1s3+Ss+eOQbscGM4cfIFBlVg/QKxyYgj26k5AnakuHkKxH6004ZtuLe5awMBotIYF2bbGDoDhpgQ4r/kcj4rQ==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.10.0.tgz",
+			"integrity": "sha512-6q1vtt5FJcg5osgkHeM1euErECNqEZ5Z1j69yiNx2luEBIso+nxCkS9nqj8w+MK5X7rvKEToGhFfOFWncs51pQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.9.2",
-				"@docusaurus/types": "3.9.2",
-				"@docusaurus/utils": "3.9.2",
-				"@docusaurus/utils-validation": "3.9.2",
+				"@docusaurus/core": "3.10.0",
+				"@docusaurus/types": "3.10.0",
+				"@docusaurus/utils": "3.10.0",
+				"@docusaurus/utils-validation": "3.10.0",
 				"tslib": "^2.6.0"
 			},
 			"engines": {
@@ -3742,14 +3766,14 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-debug": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.9.2.tgz",
-			"integrity": "sha512-j7a5hWuAFxyQAkilZwhsQ/b3T7FfHZ+0dub6j/GxKNFJp2h9qk/P1Bp7vrGASnvA9KNQBBL1ZXTe7jlh4VdPdA==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.10.0.tgz",
+			"integrity": "sha512-XcljKN+G+nmmK69uQA1d9BlYU3ZftG3T3zpK8/7Hf/wrOlV7TA4Ampdrdwkg0jElKdKAoSnPhCO0/U3bQGsVQQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.9.2",
-				"@docusaurus/types": "3.9.2",
-				"@docusaurus/utils": "3.9.2",
+				"@docusaurus/core": "3.10.0",
+				"@docusaurus/types": "3.10.0",
+				"@docusaurus/utils": "3.10.0",
 				"fs-extra": "^11.1.1",
 				"react-json-view-lite": "^2.3.0",
 				"tslib": "^2.6.0"
@@ -3763,14 +3787,14 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-google-analytics": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.9.2.tgz",
-			"integrity": "sha512-mAwwQJ1Us9jL/lVjXtErXto4p4/iaLlweC54yDUK1a97WfkC6Z2k5/769JsFgwOwOP+n5mUQGACXOEQ0XDuVUw==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.10.0.tgz",
+			"integrity": "sha512-hTEoodatpBZnUat5nFExbuTGA1lhWGy7vZGuTew5Q3QDtGKFpSJLYmZJhdTjvCFwv1+qQ67hgAVlKdJOB8TXow==",
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.9.2",
-				"@docusaurus/types": "3.9.2",
-				"@docusaurus/utils-validation": "3.9.2",
+				"@docusaurus/core": "3.10.0",
+				"@docusaurus/types": "3.10.0",
+				"@docusaurus/utils-validation": "3.10.0",
 				"tslib": "^2.6.0"
 			},
 			"engines": {
@@ -3782,15 +3806,15 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-google-gtag": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.9.2.tgz",
-			"integrity": "sha512-YJ4lDCphabBtw19ooSlc1MnxtYGpjFV9rEdzjLsUnBCeis2djUyCozZaFhCg6NGEwOn7HDDyMh0yzcdRpnuIvA==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.10.0.tgz",
+			"integrity": "sha512-iB/Zzjv/eelJRbdULZqzWCbgMgJ7ht4ONVjXtN3+BI/muil6S87gQ1OJyPwlXD+ELdKkitC7bWv5eJdYOZLhrQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.9.2",
-				"@docusaurus/types": "3.9.2",
-				"@docusaurus/utils-validation": "3.9.2",
-				"@types/gtag.js": "^0.0.12",
+				"@docusaurus/core": "3.10.0",
+				"@docusaurus/types": "3.10.0",
+				"@docusaurus/utils-validation": "3.10.0",
+				"@types/gtag.js": "^0.0.20",
 				"tslib": "^2.6.0"
 			},
 			"engines": {
@@ -3802,14 +3826,14 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-google-tag-manager": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.9.2.tgz",
-			"integrity": "sha512-LJtIrkZN/tuHD8NqDAW1Tnw0ekOwRTfobWPsdO15YxcicBo2ykKF0/D6n0vVBfd3srwr9Z6rzrIWYrMzBGrvNw==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.10.0.tgz",
+			"integrity": "sha512-FEjZxqKgLHa+Wez/EgKxRwvArNCWIScfyEQD95rot7jkxp6nonjI5XIbGfO/iYhM5Qinwe8aIEQHP2KZtpqVuA==",
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.9.2",
-				"@docusaurus/types": "3.9.2",
-				"@docusaurus/utils-validation": "3.9.2",
+				"@docusaurus/core": "3.10.0",
+				"@docusaurus/types": "3.10.0",
+				"@docusaurus/utils-validation": "3.10.0",
 				"tslib": "^2.6.0"
 			},
 			"engines": {
@@ -3821,17 +3845,17 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-sitemap": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.9.2.tgz",
-			"integrity": "sha512-WLh7ymgDXjG8oPoM/T4/zUP7KcSuFYRZAUTl8vR6VzYkfc18GBM4xLhcT+AKOwun6kBivYKUJf+vlqYJkm+RHw==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.10.0.tgz",
+			"integrity": "sha512-DVTSLjB97hIjmayGnGcBfognCeI7ZuUKgEnU7Oz81JYqXtVg94mVTthDjq3QHTylYNeCUbkaW8VF0FDLcc8pPw==",
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.9.2",
-				"@docusaurus/logger": "3.9.2",
-				"@docusaurus/types": "3.9.2",
-				"@docusaurus/utils": "3.9.2",
-				"@docusaurus/utils-common": "3.9.2",
-				"@docusaurus/utils-validation": "3.9.2",
+				"@docusaurus/core": "3.10.0",
+				"@docusaurus/logger": "3.10.0",
+				"@docusaurus/types": "3.10.0",
+				"@docusaurus/utils": "3.10.0",
+				"@docusaurus/utils-common": "3.10.0",
+				"@docusaurus/utils-validation": "3.10.0",
 				"fs-extra": "^11.1.1",
 				"sitemap": "^7.1.1",
 				"tslib": "^2.6.0"
@@ -3845,15 +3869,15 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-svgr": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.9.2.tgz",
-			"integrity": "sha512-n+1DE+5b3Lnf27TgVU5jM1d4x5tUh2oW5LTsBxJX4PsAPV0JGcmI6p3yLYtEY0LRVEIJh+8RsdQmRE66wSV8mw==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.10.0.tgz",
+			"integrity": "sha512-lNljBESaETZqVBMPqkrGchr+UPT1eZzEPLmJhz8I76BxbjqgsUnRvrq6lQJ9sYjgmgX52KB7kkgczqd2yzoswQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.9.2",
-				"@docusaurus/types": "3.9.2",
-				"@docusaurus/utils": "3.9.2",
-				"@docusaurus/utils-validation": "3.9.2",
+				"@docusaurus/core": "3.10.0",
+				"@docusaurus/types": "3.10.0",
+				"@docusaurus/utils": "3.10.0",
+				"@docusaurus/utils-validation": "3.10.0",
 				"@svgr/core": "8.1.0",
 				"@svgr/webpack": "^8.1.0",
 				"tslib": "^2.6.0",
@@ -3868,26 +3892,26 @@
 			}
 		},
 		"node_modules/@docusaurus/preset-classic": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.9.2.tgz",
-			"integrity": "sha512-IgyYO2Gvaigi21LuDIe+nvmN/dfGXAiMcV/murFqcpjnZc7jxFAxW+9LEjdPt61uZLxG4ByW/oUmX/DDK9t/8w==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.10.0.tgz",
+			"integrity": "sha512-kw/Ye02Hc6xP1OdTswy8yxQEHg0fdPpyWAQRxr5b2x3h7LlG2Zgbb5BDFROnXDDMpUxB7YejlocJIE5HIEfpNA==",
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.9.2",
-				"@docusaurus/plugin-content-blog": "3.9.2",
-				"@docusaurus/plugin-content-docs": "3.9.2",
-				"@docusaurus/plugin-content-pages": "3.9.2",
-				"@docusaurus/plugin-css-cascade-layers": "3.9.2",
-				"@docusaurus/plugin-debug": "3.9.2",
-				"@docusaurus/plugin-google-analytics": "3.9.2",
-				"@docusaurus/plugin-google-gtag": "3.9.2",
-				"@docusaurus/plugin-google-tag-manager": "3.9.2",
-				"@docusaurus/plugin-sitemap": "3.9.2",
-				"@docusaurus/plugin-svgr": "3.9.2",
-				"@docusaurus/theme-classic": "3.9.2",
-				"@docusaurus/theme-common": "3.9.2",
-				"@docusaurus/theme-search-algolia": "3.9.2",
-				"@docusaurus/types": "3.9.2"
+				"@docusaurus/core": "3.10.0",
+				"@docusaurus/plugin-content-blog": "3.10.0",
+				"@docusaurus/plugin-content-docs": "3.10.0",
+				"@docusaurus/plugin-content-pages": "3.10.0",
+				"@docusaurus/plugin-css-cascade-layers": "3.10.0",
+				"@docusaurus/plugin-debug": "3.10.0",
+				"@docusaurus/plugin-google-analytics": "3.10.0",
+				"@docusaurus/plugin-google-gtag": "3.10.0",
+				"@docusaurus/plugin-google-tag-manager": "3.10.0",
+				"@docusaurus/plugin-sitemap": "3.10.0",
+				"@docusaurus/plugin-svgr": "3.10.0",
+				"@docusaurus/theme-classic": "3.10.0",
+				"@docusaurus/theme-common": "3.10.0",
+				"@docusaurus/theme-search-algolia": "3.10.0",
+				"@docusaurus/types": "3.10.0"
 			},
 			"engines": {
 				"node": ">=20.0"
@@ -3898,26 +3922,27 @@
 			}
 		},
 		"node_modules/@docusaurus/theme-classic": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.9.2.tgz",
-			"integrity": "sha512-IGUsArG5hhekXd7RDb11v94ycpJpFdJPkLnt10fFQWOVxAtq5/D7hT6lzc2fhyQKaaCE62qVajOMKL7OiAFAIA==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.10.0.tgz",
+			"integrity": "sha512-9msCAsRdN+UG+RwPwCFb0uKy4tGoPh5YfBozXeGUtIeAgsMdn6f3G/oY861luZ3t8S2ET8S9Y/1GnpJAGWytww==",
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.9.2",
-				"@docusaurus/logger": "3.9.2",
-				"@docusaurus/mdx-loader": "3.9.2",
-				"@docusaurus/module-type-aliases": "3.9.2",
-				"@docusaurus/plugin-content-blog": "3.9.2",
-				"@docusaurus/plugin-content-docs": "3.9.2",
-				"@docusaurus/plugin-content-pages": "3.9.2",
-				"@docusaurus/theme-common": "3.9.2",
-				"@docusaurus/theme-translations": "3.9.2",
-				"@docusaurus/types": "3.9.2",
-				"@docusaurus/utils": "3.9.2",
-				"@docusaurus/utils-common": "3.9.2",
-				"@docusaurus/utils-validation": "3.9.2",
+				"@docusaurus/core": "3.10.0",
+				"@docusaurus/logger": "3.10.0",
+				"@docusaurus/mdx-loader": "3.10.0",
+				"@docusaurus/module-type-aliases": "3.10.0",
+				"@docusaurus/plugin-content-blog": "3.10.0",
+				"@docusaurus/plugin-content-docs": "3.10.0",
+				"@docusaurus/plugin-content-pages": "3.10.0",
+				"@docusaurus/theme-common": "3.10.0",
+				"@docusaurus/theme-translations": "3.10.0",
+				"@docusaurus/types": "3.10.0",
+				"@docusaurus/utils": "3.10.0",
+				"@docusaurus/utils-common": "3.10.0",
+				"@docusaurus/utils-validation": "3.10.0",
 				"@mdx-js/react": "^3.0.0",
 				"clsx": "^2.0.0",
+				"copy-text-to-clipboard": "^3.2.0",
 				"infima": "0.2.0-alpha.45",
 				"lodash": "^4.17.21",
 				"nprogress": "^0.2.0",
@@ -3938,15 +3963,15 @@
 			}
 		},
 		"node_modules/@docusaurus/theme-common": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.9.2.tgz",
-			"integrity": "sha512-6c4DAbR6n6nPbnZhY2V3tzpnKnGL+6aOsLvFL26VRqhlczli9eWG0VDUNoCQEPnGwDMhPS42UhSAnz5pThm5Ag==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.0.tgz",
+			"integrity": "sha512-Dkp1YXKn16ByCJAdIjbDIOpVb4Z66MsVD694/ilX1vAAHaVEMrVsf/NPd9VgreyFx08rJ9GqV1MtzsbTcU73Kg==",
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/mdx-loader": "3.9.2",
-				"@docusaurus/module-type-aliases": "3.9.2",
-				"@docusaurus/utils": "3.9.2",
-				"@docusaurus/utils-common": "3.9.2",
+				"@docusaurus/mdx-loader": "3.10.0",
+				"@docusaurus/module-type-aliases": "3.10.0",
+				"@docusaurus/utils": "3.10.0",
+				"@docusaurus/utils-common": "3.10.0",
 				"@types/history": "^4.7.11",
 				"@types/react": "*",
 				"@types/react-router-config": "*",
@@ -3966,16 +3991,16 @@
 			}
 		},
 		"node_modules/@docusaurus/theme-mermaid": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.9.2.tgz",
-			"integrity": "sha512-5vhShRDq/ntLzdInsQkTdoKWSzw8d1jB17sNPYhA/KvYYFXfuVEGHLM6nrf8MFbV8TruAHDG21Fn3W4lO8GaDw==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.10.0.tgz",
+			"integrity": "sha512-Y2xrlwhIJ80oOZIO3PXL6A7J869splfcMI87E3NKpYsy3zJxOyV+BP1QMtGi59ajKgU868HPuyyn6J+6BZGOBg==",
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.9.2",
-				"@docusaurus/module-type-aliases": "3.9.2",
-				"@docusaurus/theme-common": "3.9.2",
-				"@docusaurus/types": "3.9.2",
-				"@docusaurus/utils-validation": "3.9.2",
+				"@docusaurus/core": "3.10.0",
+				"@docusaurus/module-type-aliases": "3.10.0",
+				"@docusaurus/theme-common": "3.10.0",
+				"@docusaurus/types": "3.10.0",
+				"@docusaurus/utils-validation": "3.10.0",
 				"mermaid": ">=11.6.0",
 				"tslib": "^2.6.0"
 			},
@@ -3994,19 +4019,20 @@
 			}
 		},
 		"node_modules/@docusaurus/theme-search-algolia": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.9.2.tgz",
-			"integrity": "sha512-GBDSFNwjnh5/LdkxCKQHkgO2pIMX1447BxYUBG2wBiajS21uj64a+gH/qlbQjDLxmGrbrllBrtJkUHxIsiwRnw==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.10.0.tgz",
+			"integrity": "sha512-f5FPKI08e3JRG63vR/o4qeuUVHUHzFzM0nnF+AkB67soAZgNsKJRf2qmUZvlQkGwlV+QFkKe4D0ANMh1jToU3g==",
 			"license": "MIT",
 			"dependencies": {
-				"@docsearch/react": "^3.9.0 || ^4.1.0",
-				"@docusaurus/core": "3.9.2",
-				"@docusaurus/logger": "3.9.2",
-				"@docusaurus/plugin-content-docs": "3.9.2",
-				"@docusaurus/theme-common": "3.9.2",
-				"@docusaurus/theme-translations": "3.9.2",
-				"@docusaurus/utils": "3.9.2",
-				"@docusaurus/utils-validation": "3.9.2",
+				"@algolia/autocomplete-core": "^1.19.2",
+				"@docsearch/react": "^3.9.0 || ^4.3.2",
+				"@docusaurus/core": "3.10.0",
+				"@docusaurus/logger": "3.10.0",
+				"@docusaurus/plugin-content-docs": "3.10.0",
+				"@docusaurus/theme-common": "3.10.0",
+				"@docusaurus/theme-translations": "3.10.0",
+				"@docusaurus/utils": "3.10.0",
+				"@docusaurus/utils-validation": "3.10.0",
 				"algoliasearch": "^5.37.0",
 				"algoliasearch-helper": "^3.26.0",
 				"clsx": "^2.0.0",
@@ -4025,9 +4051,9 @@
 			}
 		},
 		"node_modules/@docusaurus/theme-translations": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.9.2.tgz",
-			"integrity": "sha512-vIryvpP18ON9T9rjgMRFLr2xJVDpw1rtagEGf8Ccce4CkTrvM/fRB8N2nyWYOW5u3DdjkwKw5fBa+3tbn9P4PA==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.10.0.tgz",
+			"integrity": "sha512-L9IbFLwTc5+XdgH45iQYufLn0SVZd6BUNelDbKIFlH+E4hhjuj/XHWAFMX/w2K59rfy8wak9McOaei7BSUfRPA==",
 			"license": "MIT",
 			"dependencies": {
 				"fs-extra": "^11.1.1",
@@ -4038,9 +4064,9 @@
 			}
 		},
 		"node_modules/@docusaurus/types": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-			"integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.0.tgz",
+			"integrity": "sha512-F0dOt3FOoO20rRaFK7whGFQZ3ggyrWEdQc/c8/UiRuzhtg4y1w9FspXH5zpCT07uMnJKBPGh+qNazbNlCQqvSw==",
 			"license": "MIT",
 			"dependencies": {
 				"@mdx-js/mdx": "^3.0.0",
@@ -4074,16 +4100,16 @@
 			}
 		},
 		"node_modules/@docusaurus/utils": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.9.2.tgz",
-			"integrity": "sha512-lBSBiRruFurFKXr5Hbsl2thmGweAPmddhF3jb99U4EMDA5L+e5Y1rAkOS07Nvrup7HUMBDrCV45meaxZnt28nQ==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.10.0.tgz",
+			"integrity": "sha512-T3B0WTigsIthe0D4LQa2k+7bJY+c3WS+Wq2JhcznOSpn1lSN64yNtHQXboCj3QnUs1EuAZszQG1SHKu5w5ZrlA==",
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/logger": "3.9.2",
-				"@docusaurus/types": "3.9.2",
-				"@docusaurus/utils-common": "3.9.2",
+				"@docusaurus/logger": "3.10.0",
+				"@docusaurus/types": "3.10.0",
+				"@docusaurus/utils-common": "3.10.0",
 				"escape-string-regexp": "^4.0.0",
-				"execa": "5.1.1",
+				"execa": "^5.1.1",
 				"file-loader": "^6.2.0",
 				"fs-extra": "^11.1.1",
 				"github-slugger": "^1.5.0",
@@ -4106,12 +4132,12 @@
 			}
 		},
 		"node_modules/@docusaurus/utils-common": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.9.2.tgz",
-			"integrity": "sha512-I53UC1QctruA6SWLvbjbhCpAw7+X7PePoe5pYcwTOEXD/PxeP8LnECAhTHHwWCblyUX5bMi4QLRkxvyZ+IT8Aw==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.10.0.tgz",
+			"integrity": "sha512-JyL7sb9QVDgYvudIS81Dv0lsWm7le0vGZSDwsztxWam1SPBqrnkvBy9UYL/amh6pbybkyYTd3CMTkO24oMlCSw==",
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/types": "3.9.2",
+				"@docusaurus/types": "3.10.0",
 				"tslib": "^2.6.0"
 			},
 			"engines": {
@@ -4119,14 +4145,14 @@
 			}
 		},
 		"node_modules/@docusaurus/utils-validation": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.9.2.tgz",
-			"integrity": "sha512-l7yk3X5VnNmATbwijJkexdhulNsQaNDwoagiwujXoxFbWLcxHQqNQ+c/IAlzrfMMOfa/8xSBZ7KEKDesE/2J7A==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.10.0.tgz",
+			"integrity": "sha512-c+6n2+ZPOJtWWc8Bb/EYdpSDfjYEScdCu9fB/SNjOmSCf1IdVnGf2T53o0tsz0gDRtCL90tifTL0JE/oMuP1Mw==",
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/logger": "3.9.2",
-				"@docusaurus/utils": "3.9.2",
-				"@docusaurus/utils-common": "3.9.2",
+				"@docusaurus/logger": "3.10.0",
+				"@docusaurus/utils": "3.10.0",
+				"@docusaurus/utils-common": "3.10.0",
 				"fs-extra": "^11.2.0",
 				"joi": "^17.9.2",
 				"js-yaml": "^4.1.0",
@@ -5107,9 +5133,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"license": "MIT",
 			"optional": true,
 			"peer": true,
@@ -5926,9 +5952,9 @@
 			}
 		},
 		"node_modules/@types/debug": {
-			"version": "4.1.12",
-			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-			"integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+			"integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/ms": "*"
@@ -6000,9 +6026,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/gtag.js": {
-			"version": "0.0.12",
-			"resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.12.tgz",
-			"integrity": "sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg==",
+			"version": "0.0.20",
+			"resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.20.tgz",
+			"integrity": "sha512-wwAbk3SA2QeU67unN7zPxjEHmPmlXwZXZvQEpbEUQuMCRGgKyE1m6XDuTUA9b6pCGb/GqJmdfMOY5LuDjJSbbg==",
 			"license": "MIT"
 		},
 		"node_modules/@types/hast": {
@@ -6592,34 +6618,34 @@
 			}
 		},
 		"node_modules/algoliasearch": {
-			"version": "5.49.1",
-			"resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.49.1.tgz",
-			"integrity": "sha512-X3Pp2aRQhg4xUC6PQtkubn5NpRKuUPQ9FPDQlx36SmpFwwH2N0/tw4c+NXV3nw3PsgeUs+BuWGP0gjz3TvENLQ==",
+			"version": "5.50.2",
+			"resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.50.2.tgz",
+			"integrity": "sha512-Tfp26yoNWurUjfgK4GOrVJQhSNXu9tJtHfFFNosgT2YClG+vPyUjX/gbC8rG39qLncnZg8Fj34iarQWpMkqefw==",
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/abtesting": "1.15.1",
-				"@algolia/client-abtesting": "5.49.1",
-				"@algolia/client-analytics": "5.49.1",
-				"@algolia/client-common": "5.49.1",
-				"@algolia/client-insights": "5.49.1",
-				"@algolia/client-personalization": "5.49.1",
-				"@algolia/client-query-suggestions": "5.49.1",
-				"@algolia/client-search": "5.49.1",
-				"@algolia/ingestion": "1.49.1",
-				"@algolia/monitoring": "1.49.1",
-				"@algolia/recommend": "5.49.1",
-				"@algolia/requester-browser-xhr": "5.49.1",
-				"@algolia/requester-fetch": "5.49.1",
-				"@algolia/requester-node-http": "5.49.1"
+				"@algolia/abtesting": "1.16.2",
+				"@algolia/client-abtesting": "5.50.2",
+				"@algolia/client-analytics": "5.50.2",
+				"@algolia/client-common": "5.50.2",
+				"@algolia/client-insights": "5.50.2",
+				"@algolia/client-personalization": "5.50.2",
+				"@algolia/client-query-suggestions": "5.50.2",
+				"@algolia/client-search": "5.50.2",
+				"@algolia/ingestion": "1.50.2",
+				"@algolia/monitoring": "1.50.2",
+				"@algolia/recommend": "5.50.2",
+				"@algolia/requester-browser-xhr": "5.50.2",
+				"@algolia/requester-fetch": "5.50.2",
+				"@algolia/requester-node-http": "5.50.2"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/algoliasearch-helper": {
-			"version": "3.28.0",
-			"resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.28.0.tgz",
-			"integrity": "sha512-GBN0xsxGggaCPElZq24QzMdfphrjIiV2xA+hRXE4/UMpN3nsF2WrM8q+x80OGvGpJWtB7F+4Hq5eSfWwuejXrg==",
+			"version": "3.28.1",
+			"resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.28.1.tgz",
+			"integrity": "sha512-6iXpbkkrAI5HFpCWXlNmIDSBuoN/U1XnEvb2yJAoWfqrZ+DrybI7MQ5P5mthFaprmocq+zbi6HxnR28xnZAYBw==",
 			"license": "MIT",
 			"dependencies": {
 				"@algolia/events": "^4.0.1"
@@ -6784,9 +6810,9 @@
 			}
 		},
 		"node_modules/autoprefixer": {
-			"version": "10.4.27",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
-			"integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+			"integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -6803,8 +6829,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.28.1",
-				"caniuse-lite": "^1.0.30001774",
+				"browserslist": "^4.28.2",
+				"caniuse-lite": "^1.0.30001787",
 				"fraction.js": "^5.3.4",
 				"picocolors": "^1.1.1",
 				"postcss-value-parser": "^4.2.0"
@@ -6846,13 +6872,13 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
-			"version": "0.4.15",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.15.tgz",
-			"integrity": "sha512-hR3GwrRwHUfYwGfrisXPIDP3JcYfBrW7wKE7+Au6wDYl7fm/ka1NEII6kORzxNU556JjfidZeBsO10kYvtV1aw==",
+			"version": "0.4.17",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
+			"integrity": "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/compat-data": "^7.28.6",
-				"@babel/helper-define-polyfill-provider": "^0.6.6",
+				"@babel/helper-define-polyfill-provider": "^0.6.8",
 				"semver": "^6.3.1"
 			},
 			"peerDependencies": {
@@ -6882,12 +6908,12 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-regenerator": {
-			"version": "0.6.6",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.6.tgz",
-			"integrity": "sha512-hYm+XLYRMvupxiQzrvXUj7YyvFFVfv5gI0R71AJzudg1g2AI2vyCPPIFEBjk162/wFzti3inBHo7isWFuEVS/A==",
+			"version": "0.6.8",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
+			"integrity": "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.6.6"
+				"@babel/helper-define-polyfill-provider": "^0.6.8"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -6910,9 +6936,9 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-			"integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+			"version": "2.10.20",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
+			"integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
 			"license": "Apache-2.0",
 			"bin": {
 				"baseline-browser-mapping": "dist/cli.cjs"
@@ -7047,9 +7073,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -7069,9 +7095,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.28.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-			"integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+			"version": "4.28.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -7088,11 +7114,11 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"baseline-browser-mapping": "^2.9.0",
-				"caniuse-lite": "^1.0.30001759",
-				"electron-to-chromium": "^1.5.263",
-				"node-releases": "^2.0.27",
-				"update-browserslist-db": "^1.2.0"
+				"baseline-browser-mapping": "^2.10.12",
+				"caniuse-lite": "^1.0.30001782",
+				"electron-to-chromium": "^1.5.328",
+				"node-releases": "^2.0.36",
+				"update-browserslist-db": "^1.2.3"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -7168,14 +7194,14 @@
 			}
 		},
 		"node_modules/call-bind": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-			"integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+			"integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
 			"license": "MIT",
 			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.0",
-				"es-define-property": "^1.0.0",
-				"get-intrinsic": "^1.2.4",
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"get-intrinsic": "^1.3.0",
 				"set-function-length": "^1.2.2"
 			},
 			"engines": {
@@ -7258,9 +7284,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001776",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001776.tgz",
-			"integrity": "sha512-sg01JDPzZ9jGshqKSckOQthXnYwOEP50jeVFhaSFbZcOy05TiuuaffDOfcwtCisJ9kNQuLBFibYywv2Bgm9osw==",
+			"version": "1.0.30001788",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+			"integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -7391,29 +7417,31 @@
 			}
 		},
 		"node_modules/chevrotain": {
-			"version": "11.1.2",
-			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
-			"integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
+			"integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@chevrotain/cst-dts-gen": "11.1.2",
-				"@chevrotain/gast": "11.1.2",
-				"@chevrotain/regexp-to-ast": "11.1.2",
-				"@chevrotain/types": "11.1.2",
-				"@chevrotain/utils": "11.1.2",
-				"lodash-es": "4.17.23"
+				"@chevrotain/cst-dts-gen": "12.0.0",
+				"@chevrotain/gast": "12.0.0",
+				"@chevrotain/regexp-to-ast": "12.0.0",
+				"@chevrotain/types": "12.0.0",
+				"@chevrotain/utils": "12.0.0"
+			},
+			"engines": {
+				"node": ">=22.0.0"
 			}
 		},
 		"node_modules/chevrotain-allstar": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
-			"integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.1.tgz",
+			"integrity": "sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA==",
 			"license": "MIT",
 			"dependencies": {
 				"lodash-es": "^4.17.21"
 			},
 			"peerDependencies": {
-				"chevrotain": "^11.0.0"
+				"chevrotain": "^12.0.0"
 			}
 		},
 		"node_modules/chokidar": {
@@ -7805,6 +7833,18 @@
 			"integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
 			"license": "MIT"
 		},
+		"node_modules/copy-text-to-clipboard": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.2.tgz",
+			"integrity": "sha512-T6SqyLd1iLuqPA90J5N4cTalrtovCySh58iiZDGJ6FGznbclKh4UI+FGacQSgFzwKG77W7XT5gwbVEbd9cIH1A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/copy-webpack-plugin": {
 			"version": "11.0.0",
 			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-11.0.0.tgz",
@@ -7884,24 +7924,13 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.48.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.48.0.tgz",
-			"integrity": "sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==",
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+			"integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.28.1"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/core-js"
-			}
-		},
-		"node_modules/core-js-pure": {
-			"version": "3.48.0",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.48.0.tgz",
-			"integrity": "sha512-1slJgk89tWC51HQ1AEqG+s2VuwpTRr8ocu4n20QUcH1v9lAN0RXen0Q0AABa/DK1I7RrNWLucplOHMx8hfTGTw==",
-			"hasInstallScript": true,
-			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/core-js"
@@ -8028,9 +8057,9 @@
 			}
 		},
 		"node_modules/css-declaration-sorter": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.3.1.tgz",
-			"integrity": "sha512-gz6x+KkgNCjxq3Var03pRYLhyNfwhkKF1g/yoLgDNtFvVu0/fOLV9C8fFEZRjACp/XQLumjAYo7JVjzH3wLbxA==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.4.0.tgz",
+			"integrity": "sha512-LTuzjPoyA2vMGKKcaOqKSp7Ub2eGrNfKiZH4LpezxpNrsICGCSFvsQOI29psISxNZtaXibkC2CXzrQ5enMeGGw==",
 			"license": "ISC",
 			"engines": {
 				"node": "^14 || ^16 || >=18"
@@ -9254,13 +9283,10 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
-			"integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+			"integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
-			"engines": {
-				"node": ">=20"
-			},
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
 			}
@@ -9346,9 +9372,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.307",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
-			"integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
+			"version": "1.5.340",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+			"integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
 			"license": "ISC"
 		},
 		"node_modules/emoji-regex": {
@@ -9845,9 +9871,9 @@
 			"license": "MIT"
 		},
 		"node_modules/express/node_modules/path-to-regexp": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-			"integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+			"integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
 			"license": "MIT"
 		},
 		"node_modules/express/node_modules/range-parser": {
@@ -10147,9 +10173,9 @@
 			}
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.11",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-			"integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+			"integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
 			"funding": [
 				{
 					"type": "individual",
@@ -11837,13 +11863,14 @@
 			}
 		},
 		"node_modules/langium": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/langium/-/langium-4.2.1.tgz",
-			"integrity": "sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/langium/-/langium-4.2.2.tgz",
+			"integrity": "sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ==",
 			"license": "MIT",
 			"dependencies": {
-				"chevrotain": "~11.1.1",
-				"chevrotain-allstar": "~0.3.1",
+				"@chevrotain/regexp-to-ast": "~12.0.0",
+				"chevrotain": "~12.0.0",
+				"chevrotain-allstar": "~0.4.1",
 				"vscode-languageserver": "~9.0.1",
 				"vscode-languageserver-textdocument": "~1.0.11",
 				"vscode-uri": "~3.1.0"
@@ -11954,15 +11981,15 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"license": "MIT"
 		},
 		"node_modules/lodash-es": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-			"integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+			"integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.debounce": {
@@ -14437,9 +14464,9 @@
 			}
 		},
 		"node_modules/mini-css-extract-plugin": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.10.0.tgz",
-			"integrity": "sha512-540P2c5dYnJlyJxTaSloliZexv8rji6rY8FhQN+WF/82iHQfA23j/xtJx97L+mXOML27EqksSek/g4eK7jaL3g==",
+			"version": "2.10.2",
+			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.10.2.tgz",
+			"integrity": "sha512-AOSS0IdEB95ayVkxn5oGzNQwqAi2J0Jb/kKm43t7H73s8+f5873g0yuj0PNvK4dO75mu5DHg4nlgp4k6Kga8eg==",
 			"license": "MIT",
 			"dependencies": {
 				"schema-utils": "^4.0.0",
@@ -15159,9 +15186,9 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
@@ -15230,9 +15257,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.8",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+			"version": "8.5.10",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+			"integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -17042,9 +17069,9 @@
 			}
 		},
 		"node_modules/react-loadable-ssr-addon-v5-slorber": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/react-loadable-ssr-addon-v5-slorber/-/react-loadable-ssr-addon-v5-slorber-1.0.1.tgz",
-			"integrity": "sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/react-loadable-ssr-addon-v5-slorber/-/react-loadable-ssr-addon-v5-slorber-1.0.3.tgz",
+			"integrity": "sha512-GXfh9VLwB5ERaCsU6RULh7tkemeX15aNh6wuMEBtfdyMa7fFG8TXrhXlx1SoEK2Ty/l6XIkzzYIQmyaWW3JgdQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.10.3"
@@ -17298,9 +17325,9 @@
 			"license": "MIT"
 		},
 		"node_modules/regjsparser": {
-			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz",
-			"integrity": "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==",
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
+			"integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"jsesc": "~3.1.0"
@@ -17609,11 +17636,12 @@
 			"license": "MIT"
 		},
 		"node_modules/resolve": {
-			"version": "1.22.11",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-			"integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+			"version": "1.22.12",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+			"integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
 			"license": "MIT",
 			"dependencies": {
+				"es-errors": "^1.3.0",
 				"is-core-module": "^2.16.1",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
@@ -17878,9 +17906,9 @@
 			}
 		},
 		"node_modules/sax": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
-			"integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+			"integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=11.0.0"
@@ -18032,9 +18060,9 @@
 			}
 		},
 		"node_modules/serialize-javascript": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
-			"integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+			"integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=20.0.0"


### PR DESCRIPTION
## Summary

- Ran `npm audit fix` in `website/`, clearing all 31 advisories (22 moderate, 9 high). Lockfile-only, no `package.json` changes. Supersedes the open dependabot PRs for picomatch, path-to-regexp, lodash, follow-redirects, and dompurify.
- Fixed a broken link on the `/docs/` landing page. `docs/README.md` linked to the non-markdown `LICENSE` file, which Docusaurus does not serve as a route. Now points at the GitHub blob URL.

## Test plan

- [x] `npm install && npm audit` reports 0 vulnerabilities
- [x] `npm run build` succeeds with no broken-link warnings (only the pre-existing vscode-languageserver umd warning from mermaid's dep chain)

Closes #795
Closes #796
Closes #798
Closes #799
Closes #800